### PR TITLE
refactor(polaris.yaml): 补充api.bindIf的配置描述

### DIFF
--- a/polaris.yaml
+++ b/polaris.yaml
@@ -50,7 +50,7 @@ global:
     #默认值:1s
     retryInterval: 1s
     #描述:客户端绑定的网卡地址
-    bindIf: eth0
+    bindIf: 
   #描述:对接polaris server的相关配置
   serverConnector:
     #描述:访问server的连接协议，SDK会根据协议名称会加载对应的插件

--- a/polaris.yaml
+++ b/polaris.yaml
@@ -49,6 +49,8 @@ global:
     #范围:[1s:...]
     #默认值:1s
     retryInterval: 1s
+    #描述:客户端绑定的网卡地址
+    bindIf: eth0
   #描述:对接polaris server的相关配置
   serverConnector:
     #描述:访问server的连接协议，SDK会根据协议名称会加载对应的插件


### PR DESCRIPTION
prometheus插件会使用api的bindIpValue作为target的host，可以在配置文中配置bindIf来让polaris自动获取本机ip，
这个配置没有体现.