### PR TITLE
fix:动态路由中，支持destination的值'*'匹配

### DIFF
--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -359,6 +359,10 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			// 首先如果元数据的value无法获取，直接匹配失败
 			return nil, false, "", nil
 		}
+		// 全匹配类型直接返回全量实例
+		if ruleMetaValueStr == matchAll && ruleMetaValue.ValueType == apimodel.MatchString_TEXT {
+			return cls, true, "", nil
+		}
 		metaValues := svcCache.GetInstanceMetaValues(cls.Location, ruleMetaKey)
 		if len(metaValues) == 0 {
 			// 不匹配
@@ -400,9 +404,6 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			// 校验从上一个路由插件继承下来的规则是否符合该目标规则
 			if !validateInMetadata(ruleMetaKey, ruleMetaValue, ruleMetaValueStr, inCluster.Metadata, nil) {
 				return nil, false, "", nil
-			}
-			if ruleMetaValueStr == matchAll && ruleMetaValue.ValueType == apimodel.MatchString_TEXT {
-				return cls, true, "", nil
 			}
 			if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
 				if cls.RuleAddMetadata(ruleMetaKey, ruleMetaValueStr, composedValue) {

--- a/plugin/servicerouter/rulebase/base.go
+++ b/plugin/servicerouter/rulebase/base.go
@@ -401,6 +401,9 @@ func (g *RuleBasedInstancesFilter) matchDstMetadata(routeInfo *servicerouter.Rou
 			if !validateInMetadata(ruleMetaKey, ruleMetaValue, ruleMetaValueStr, inCluster.Metadata, nil) {
 				return nil, false, "", nil
 			}
+			if ruleMetaValueStr == matchAll && ruleMetaValue.ValueType == apimodel.MatchString_TEXT {
+				return cls, true, "", nil
+			}
 			if composedValue, ok := metaValues[ruleMetaValueStr]; ok {
 				if cls.RuleAddMetadata(ruleMetaKey, ruleMetaValueStr, composedValue) {
 					metaChanged = true


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes 动态路由中，支持destination的值'*'匹配

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [X] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**
![image](https://github.com/polarismesh/polaris-go/assets/66229105/7884b30a-311b-49c5-8529-f2c516ba730e)
现在的 source 来源的规则支持 '*' 匹配，destination 值匹配也需要支持全匹配 

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
