### PR TITLE
feat: 连接北极星获取自身IP时增加超时，防止阻塞住

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -334,7 +334,8 @@ func initSelfIP(cfg config.Configuration) {
 		return
 	}
 
-	conn, _ := net.Dial("tcp", address[0])
+	timeout := cfg.GetGlobal().GetServerConnector().GetConnectTimeout()
+	conn, _ := net.DialTimeout("tcp", address[0], timeout)
 	if conn != nil {
 		localAddr := conn.LocalAddr().String()
 		colonIdx := strings.LastIndex(localAddr, ":")


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes #

当北极星地址配置为不可达地址时，`initSelfIP` 函数会阻塞住。
改为使用  `DiatTimeout` 函数

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
