### PR TITLE
[fix] plugin/circuitbreaker/composite/rule.go中rule.RuleMatcher.Destination.Method为nil的问题

### DIFF
--- a/plugin/circuitbreaker/composite/rule.go
+++ b/plugin/circuitbreaker/composite/rule.go
@@ -210,11 +210,9 @@ func sortCircuitBreakerRules(rules []*fault_tolerance.CircuitBreakerRule) []*fau
 		// 1. compare destination service
 		destNamespace1 := rule1.RuleMatcher.Destination.Namespace
 		destService1 := rule1.RuleMatcher.Destination.Service
-		destMethod1 := rule1.RuleMatcher.Destination.Method.Value.Value
 
 		destNamespace2 := rule2.RuleMatcher.Destination.Namespace
 		destService2 := rule2.RuleMatcher.Destination.Service
-		destMethod2 := rule2.RuleMatcher.Destination.Method.Value.Value
 
 		svcResult := compareService(destNamespace1, destService1, destNamespace2, destService2)
 		if svcResult != 0 {
@@ -222,6 +220,8 @@ func sortCircuitBreakerRules(rules []*fault_tolerance.CircuitBreakerRule) []*fau
 		}
 		if rule1.Level == rule2.Level {
 			if rule1.Level == fault_tolerance.Level_METHOD {
+				destMethod1 := rule1.RuleMatcher.Destination.Method.Value.Value
+				destMethod2 := rule2.RuleMatcher.Destination.Method.Value.Value
 				methodResult := compareStringValue(destMethod1, destMethod2)
 				if methodResult != 0 {
 					return methodResult < 0


### PR DESCRIPTION
- 修复sortCircuitBreakerRules函数中![polaris-go-bug](https://github.com/polarismesh/polaris-go/assets/33077139/1aeeb03d-24e7-4206-afd8-5e7e384534a9)在rule类型为SERVICE或INSTANCE时为nil的问题。

**Please provide issue(s) of this PR:**
Fixes #

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration
- [ ] Docs
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
