### PR TITLE
fix(network): do not lazyClose connections of unregistered ClusterType

### DIFF
--- a/pkg/network/conn.go
+++ b/pkg/network/conn.go
@@ -135,8 +135,12 @@ func (c *Connection) Release(opKey string) {
 		return
 	}
 	// lazy closing short connections
-	if DefaultServerServiceToConnectionControl[c.ConnID.Service.ClusterType] == ConnectionShort &&
-		IsAvailableConnection(c) {
+	// 仅当显式声明为短连接的 ClusterType 才在 Release 时 lazyClose；
+	// 未在 DefaultServerServiceToConnectionControl 注册的 ClusterType（如 BuiltinCluster）
+	// 不应被当作短连接，否则其连接被 lazyClose 后会被 discover 的 clearSwitchedClient 当成
+	// "已切换" 立即关流，引发 grpc: the client connection is closing 之类的竞争错误。
+	if ctrl, ok := DefaultServerServiceToConnectionControl[c.ConnID.Service.ClusterType]; ok &&
+		ctrl == ConnectionShort && IsAvailableConnection(c) {
 		c.lazyClose(false)
 	}
 }

--- a/pkg/network/conn.go
+++ b/pkg/network/conn.go
@@ -139,7 +139,7 @@ func (c *Connection) Release(opKey string) {
 	// 未在 DefaultServerServiceToConnectionControl 注册的 ClusterType（如 BuiltinCluster）
 	// 不应被当作短连接，否则其连接被 lazyClose 后会被 discover 的 clearSwitchedClient 当成
 	// "已切换" 立即关流，引发 grpc: the client connection is closing 之类的竞争错误。
-	if ctrl, ok := DefaultServerServiceToConnectionControl[c.ConnID.Service.ClusterType]; ok &&
+	if ctrl, ok := DefaultServerServiceToConnectionControl[c.Service.ClusterType]; ok &&
 		ctrl == ConnectionShort && IsAvailableConnection(c) {
 		c.lazyClose(false)
 	}

--- a/pkg/network/conn_test.go
+++ b/pkg/network/conn_test.go
@@ -1,0 +1,144 @@
+/**
+ * Tencent is pleased to support the open source community by making polaris-go available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package network
+
+import (
+	"testing"
+
+	"github.com/polarismesh/polaris-go/pkg/config"
+	"github.com/polarismesh/polaris-go/pkg/log"
+)
+
+// fakeClosableConn 仅用于测试，不实际持有任何 grpc 资源。
+type fakeClosableConn struct {
+	closed bool
+}
+
+func (f *fakeClosableConn) Close() error {
+	f.closed = true
+	return nil
+}
+
+// noopLogger 在测试中替代未初始化的全局日志。
+type noopLogger struct{}
+
+func (noopLogger) Tracef(string, ...interface{})       {}
+func (noopLogger) Debugf(string, ...interface{})       {}
+func (noopLogger) Infof(string, ...interface{})        {}
+func (noopLogger) Warnf(string, ...interface{})        {}
+func (noopLogger) Errorf(string, ...interface{})       {}
+func (noopLogger) Fatalf(string, ...interface{})       {}
+func (noopLogger) IsLevelEnabled(int) bool             { return false }
+func (noopLogger) SetLogLevel(int) error               { return nil }
+
+var _ log.Logger = noopLogger{}
+
+func newTestConn(clusterType config.ClusterType) *Connection {
+	return &Connection{
+		Conn: &fakeClosableConn{},
+		ConnID: ConnID{
+			ID: 1,
+			Service: config.ClusterService{
+				ClusterType: clusterType,
+			},
+			Address: "127.0.0.1:8091",
+		},
+		logNetwork: noopLogger{},
+	}
+}
+
+// TestRelease_BuiltinClusterShouldNotLazyClose 防回归：BuiltinCluster 不在
+// DefaultServerServiceToConnectionControl 中，Release 时不应被当成短连接 lazyClose。
+// 这是 lossless register 与 ReportClient 共用同一条 builtin 连接时引发
+// "grpc: the client connection is closing" 报错的根因。
+func TestRelease_BuiltinClusterShouldNotLazyClose(t *testing.T) {
+	conn := newTestConn(config.BuiltinCluster)
+	if !conn.acquire("test") {
+		t.Fatalf("acquire should succeed on a fresh connection")
+	}
+	conn.Release("test")
+	if !IsAvailableConnection(conn) {
+		t.Fatalf("BuiltinCluster connection must remain available after Release; got lazyDestroy=1")
+	}
+}
+
+// TestRelease_DiscoverClusterIsLongConnection long 连接也不应在 Release 时 lazyClose。
+func TestRelease_DiscoverClusterIsLongConnection(t *testing.T) {
+	conn := newTestConn(config.DiscoverCluster)
+	if !conn.acquire("test") {
+		t.Fatalf("acquire should succeed on a fresh connection")
+	}
+	conn.Release("test")
+	if !IsAvailableConnection(conn) {
+		t.Fatalf("DiscoverCluster (long connection) must remain available after Release")
+	}
+}
+
+// TestRelease_HealthCheckClusterIsShortConnection short 连接 Release 之后必须被 lazyClose。
+// 这是历史行为，确保改动没有打翻它。
+func TestRelease_HealthCheckClusterIsShortConnection(t *testing.T) {
+	conn := newTestConn(config.HealthCheckCluster)
+	if !conn.acquire("test") {
+		t.Fatalf("acquire should succeed on a fresh connection")
+	}
+	conn.Release("test")
+	if IsAvailableConnection(conn) {
+		t.Fatalf("HealthCheckCluster (short connection) must be lazyClose'd after Release")
+	}
+}
+
+// TestRelease_UnknownClusterTypeShouldNotLazyClose 任意未注册到
+// DefaultServerServiceToConnectionControl 的 ClusterType 也不应被默认当成短连接。
+// 防止再次因 map 缺键的零值（ConnectionShort=0）导致与本次相同的隐式 bug 复发。
+func TestRelease_UnknownClusterTypeShouldNotLazyClose(t *testing.T) {
+	conn := newTestConn(config.ClusterType("not-registered-in-control-map"))
+	if !conn.acquire("test") {
+		t.Fatalf("acquire should succeed on a fresh connection")
+	}
+	conn.Release("test")
+	if !IsAvailableConnection(conn) {
+		t.Fatalf("unknown ClusterType must remain available after Release; map miss must not imply short connection")
+	}
+}
+
+// TestRelease_ShortConnectionFinalReleaseClosesUnderlying 端到端覆盖短连接的引用
+// 计数 + lazyClose 协同链路：在 ref>0 期间只标记 lazyDestroy、不关闭底层 TCP；
+// 最终 Release 让 closeConnection 真正落到底层 Close()。
+func TestRelease_ShortConnectionFinalReleaseClosesUnderlying(t *testing.T) {
+	conn := newTestConn(config.HealthCheckCluster)
+	if !conn.acquire("a") {
+		t.Fatalf("first acquire should succeed")
+	}
+	if !conn.acquire("b") {
+		t.Fatalf("second acquire should succeed")
+	}
+	fake := conn.Conn.(*fakeClosableConn)
+
+	conn.Release("a") // ref: 2 -> 1，触发 lazyClose 但不关 TCP
+	if fake.closed {
+		t.Fatalf("underlying conn must not be closed while ref>0")
+	}
+	if IsAvailableConnection(conn) {
+		t.Fatalf("short connection should be lazyDestroy'd after first Release, even with ref>0")
+	}
+
+	conn.Release("b") // ref: 1 -> 0 + lazyDestroy=1 -> closeConnection
+	if !fake.closed {
+		t.Fatalf("underlying conn must be closed after final Release")
+	}
+}


### PR DESCRIPTION

## 一、修改前后代码对比

### 修改前
```go
// lazy closing short connections
if DefaultServerServiceToConnectionControl[c.ConnID.Service.ClusterType] == ConnectionShort &&
    IsAvailableConnection(c) {
    c.lazyClose(false)
}
```

### 修改后
```go
// lazy closing short connections
// 仅当显式声明为短连接的 ClusterType 才在 Release 时 lazyClose；
// 未在 DefaultServerServiceToConnectionControl 注册的 ClusterType（如 BuiltinCluster）
// 不应被当作短连接，否则其连接被 lazyClose 后会被 discover 的 clearSwitchedClient 当成
// "已切换" 立即关流，引发 grpc: the client connection is closing 之类的竞争错误。
if ctrl, ok := DefaultServerServiceToConnectionControl[c.Service.ClusterType]; ok &&
  ctrl == ConnectionShort && IsAvailableConnection(c) {
  c.lazyClose(false)
}
```

## 二、关键差异

核心改动是 **从 map 直接取值 → 改成 `comma‑ok` 形式判断 key 是否存在**。

| 项目 | 修改前 | 修改后 |
|------|--------|--------|
| map 取值方式 | `m[key] == ConnectionShort` | `ctrl, ok := m[key]; ok && ctrl == ConnectionShort` |
| key 不存在时 | 返回零值 `int(0)`，**正好等于 `ConnectionShort`**（见 `iota` 枚举）→ 命中条件 | `ok==false`，**不进入分支** |
| 行为后果 | 未注册的 ClusterType 会被误判为短连接，触发 `lazyClose(false)` | 未注册的 ClusterType 不再走 `lazyClose(false)`，连接保持长连接行为 |
| 注释 | 无 | 增加了 4 行解释为什么必须显式判断 |

## 三、为什么要这么改（修复了什么 bug）

看一下枚举定义就明白这是个**典型的 Go map 零值陷阱**：

```go
const (
    ConnectionShort int = iota   // 0  ← map 不存在 key 时返回的零值
    ConnectionLong              // 1
)
```

`DefaultServerServiceToConnectionControl` 里只注册了 4 类 cluster：
```go
DiscoverCluster:    ConnectionLong,
ConfigCluster:      ConnectionLong,
HealthCheckCluster: ConnectionShort,
MonitorCluster:     ConnectionShort,
```

- 修改前：`m[BuiltinCluster]` 返回 `0`，恰好等于 `ConnectionShort`，于是每次 `Release` 都会把它当短连接 `lazyClose(false)` 掉。  
- 这个被 `lazyClose` 标记的连接会被 discover 模块的 `clearSwitchedClient` 误判为"已切换/可清理"的旧连接，**直接强制关闭底层 gRPC 流**。  
- 紧接着如果还有 RPC 在路上，就会拿到 gRPC 报错：

```
rpc error: code = Canceled desc = grpc: the client connection is closing
```

## 修复后的效果

- `BuiltinCluster` 等未在表中显式声明的 ClusterType 不再被错误地当作短连接，连接会按长连接方式复用。  

简而言之：**这是一个用 `comma‑ok` 修复 Go map 零值与枚举 `iota=0` 撞车的 bug 修复**，顺带解决了 polaris-network.log日志中报错 `grpc: the client connection is closing` 的问题。