### PR TITLE
feat: 熔断支持自定义降级

### DIFF
--- a/examples/circuitbreaker/README.md
+++ b/examples/circuitbreaker/README.md
@@ -518,11 +518,11 @@ svr.reportCircuitBreak(instance, model.RetSuccess, "200", start)
 5. 通过 `/switch` 翻转 provider 状态验证恢复链路
 6. 退出时自动删除所创建的熔断规则并清理进程
 
-共 11 个用例（详见 `test.md`）：`instance` / `service` / `interface` / `old_instance` /
+共 10 个用例（详见 `test.md`）：`instance` / `service` / `interface` / `old_instance` /
 `http_status` / `default_rule` / `modify_rule` / `protocol_method` / `pathtype` /
-`all_dead_fallback` / `custom_fallback`。其中 **`custom_fallback`** 验证规则配置的自定义降级
-响应（`FallbackConfig`）：SERVICE/METHOD 级各跑正向（`enable=true` 返回 `code=599`/`body`/`headers`）
-和反向（`enable=false` 熔断回 503）。
+`all_dead_fallback`。其中用例 2/3 末尾各追加了 fallback 子阶段，通过 PUT 更新现有规则切换
+`fallbackConfig.enable` 验证自定义降级响应：正向（`enable=true` 返回 `code=599`/`body`/`headers`）
+和反向（`enable=false` 回退 503），无需创建独立规则。
 
 > 提速说明：规则 `sleepWindow` 已从 12s 收紧到 6s，`--wait-half-open` 默认 8s、
 > `--wait-rule-ready` 默认 5s，全量用例耗时显著下降。
@@ -531,13 +531,13 @@ svr.reportCircuitBreak(instance, model.RetSuccess, "200", start)
 
 ```bash
 chmod +x verify_circuitbreaker.sh
-./verify_circuitbreaker.sh                                              # 跑全部用例（默认 11 个）
+./verify_circuitbreaker.sh                                              # 跑全部用例（默认 10 个）
 ./verify_circuitbreaker.sh --polaris-server 10.0.0.1                    # 指定北极星地址
 ./verify_circuitbreaker.sh --only instance                              # 仅跑实例级
 ./verify_circuitbreaker.sh --only service,interface,http_status         # 多个用例组合
 ./verify_circuitbreaker.sh --only default_rule                          # 仅跑默认规则兜底用例
 ./verify_circuitbreaker.sh --only protocol_method,pathtype              # 仅跑高级匹配维度用例
-./verify_circuitbreaker.sh --only custom_fallback                       # 仅跑自定义降级用例（SERVICE/METHOD 正反向）
+./verify_circuitbreaker.sh --only all_dead_fallback                    # 仅跑全死全活兜底用例
 ```
 
 ### 关键选项
@@ -548,7 +548,7 @@ chmod +x verify_circuitbreaker.sh
 | `--polaris-token <令牌>`    | 北极星鉴权令牌                                                     |
 | `--namespace <ns>`          | 命名空间（默认 `default`）                                         |
 | `--service <name>`          | 被调服务名（默认 `CircuitBreakerCallee`）                          |
-| `--only <列表>`             | 仅运行指定用例：`instance`, `service`, `interface`, `old_instance`, `http_status`, `default_rule`, `modify_rule`, `protocol_method`, `pathtype`, `all_dead_fallback`, `custom_fallback` |
+| `--only <列表>`             | 仅运行指定用例：`instance`, `service`, `interface`, `old_instance`, `http_status`, `default_rule`, `modify_rule`, `protocol_method`, `pathtype`, `all_dead_fallback` |
 | `--trigger-count <次数>`    | 触发阶段请求次数（默认 15，越大越容易触发熔断）                    |
 | `--recovery-count <次数>`   | 验证 / 恢复阶段请求次数（默认 10）                                 |
 | `--wait-half-open <秒数>`   | 服务级用例等待 sleepWindow 进入半开的秒数（默认 8，规则 sleepWindow=6s + 2s buffer）   |

--- a/examples/circuitbreaker/README.md
+++ b/examples/circuitbreaker/README.md
@@ -513,21 +513,31 @@ svr.reportCircuitBreak(instance, model.RetSuccess, "200", start)
 脚本会：
 1. 编译 `provider-a` / `provider-b` 与三种 consumer
 2. 启动 Provider 集群（注册到 `CircuitBreakerCallee` 服务）
-3. 通过 Polaris HTTP API 自动创建 `Level=INSTANCE/SERVICE/METHOD` 三条熔断规则
+3. 通过 Polaris HTTP API 自动创建 `Level=INSTANCE/SERVICE/METHOD` 各级熔断规则
 4. 启动对应 consumer，并发请求触发熔断
 5. 通过 `/switch` 翻转 provider 状态验证恢复链路
 6. 退出时自动删除所创建的熔断规则并清理进程
+
+共 11 个用例（详见 `test.md`）：`instance` / `service` / `interface` / `old_instance` /
+`http_status` / `default_rule` / `modify_rule` / `protocol_method` / `pathtype` /
+`all_dead_fallback` / `custom_fallback`。其中 **`custom_fallback`** 验证规则配置的自定义降级
+响应（`FallbackConfig`）：SERVICE/METHOD 级各跑正向（`enable=true` 返回 `code=599`/`body`/`headers`）
+和反向（`enable=false` 熔断回 503）。
+
+> 提速说明：规则 `sleepWindow` 已从 12s 收紧到 6s，`--wait-half-open` 默认 8s、
+> `--wait-rule-ready` 默认 5s，全量用例耗时显著下降。
 
 ### 基本用法
 
 ```bash
 chmod +x verify_circuitbreaker.sh
-./verify_circuitbreaker.sh                                              # 跑全部用例（默认 9 个）
+./verify_circuitbreaker.sh                                              # 跑全部用例（默认 11 个）
 ./verify_circuitbreaker.sh --polaris-server 10.0.0.1                    # 指定北极星地址
 ./verify_circuitbreaker.sh --only instance                              # 仅跑实例级
 ./verify_circuitbreaker.sh --only service,interface,http_status         # 多个用例组合
 ./verify_circuitbreaker.sh --only default_rule                          # 仅跑默认规则兜底用例
 ./verify_circuitbreaker.sh --only protocol_method,pathtype              # 仅跑高级匹配维度用例
+./verify_circuitbreaker.sh --only custom_fallback                       # 仅跑自定义降级用例（SERVICE/METHOD 正反向）
 ```
 
 ### 关键选项
@@ -538,10 +548,10 @@ chmod +x verify_circuitbreaker.sh
 | `--polaris-token <令牌>`    | 北极星鉴权令牌                                                     |
 | `--namespace <ns>`          | 命名空间（默认 `default`）                                         |
 | `--service <name>`          | 被调服务名（默认 `CircuitBreakerCallee`）                          |
-| `--only <列表>`             | 仅运行指定用例：`instance`, `service`, `interface`, `old_instance`, `http_status`, `default_rule`, `modify_rule`, `protocol_method`, `pathtype` |
+| `--only <列表>`             | 仅运行指定用例：`instance`, `service`, `interface`, `old_instance`, `http_status`, `default_rule`, `modify_rule`, `protocol_method`, `pathtype`, `all_dead_fallback`, `custom_fallback` |
 | `--trigger-count <次数>`    | 触发阶段请求次数（默认 15，越大越容易触发熔断）                    |
 | `--recovery-count <次数>`   | 验证 / 恢复阶段请求次数（默认 10）                                 |
-| `--wait-half-open <秒数>`   | 服务级用例等待 sleepWindow 进入半开的秒数（默认 35）               |
+| `--wait-half-open <秒数>`   | 服务级用例等待 sleepWindow 进入半开的秒数（默认 8，规则 sleepWindow=6s + 2s buffer）   |
 | `--debug`                   | 透传 `--debug=true` 给所有 provider/consumer 子进程，开启 Polaris SDK DEBUG 日志；demo 自身日志默认携带 `文件:行号` |
 
 ### 输出示例

--- a/examples/circuitbreaker/invokeHandlerCaller/consumer/main.go
+++ b/examples/circuitbreaker/invokeHandlerCaller/consumer/main.go
@@ -283,10 +283,11 @@ func (svr *PolarisClient) runWebServer() {
 				if aborted.HasFallback() {
 					replyStatus = aborted.GetFallbackCode()
 					replyBody = aborted.GetFallbackBody()
-					rw.WriteHeader(replyStatus)
+					// 必须先写 header 再 WriteHeader：net/http 在 WriteHeader 后追加的 header 会被丢弃。
 					for k, v := range aborted.GetFallbackHeaders() {
 						rw.Header().Add(k, v)
 					}
+					rw.WriteHeader(replyStatus)
 					_, _ = rw.Write([]byte(replyBody))
 					return
 				}

--- a/examples/circuitbreaker/newCircuitBreakerCaller/consumer/main.go
+++ b/examples/circuitbreaker/newCircuitBreakerCaller/consumer/main.go
@@ -326,21 +326,19 @@ func (svr *PolarisClient) makeDecorator(path string) model.DecoratorFunction {
 //
 // 返回 (status, body) 便于调用方在 logReply 中按 HTTP 真实响应记录。
 func writeResult(rw http.ResponseWriter, ret interface{}, abort *model.CallAborted, err error) (int, string) {
-	if err != nil {
-		body := fmt.Sprintf("[error] fail : %s", err)
-		rw.WriteHeader(http.StatusInternalServerError)
-		_, _ = rw.Write([]byte(body))
-		return http.StatusInternalServerError, body
-	}
+	// 注意：熔断拦截时装饰器同时返回 abort != nil 且 err == ErrorCallAborted（非 nil），
+	// 因此必须先判 abort 再判 err，否则 fallback / 503 分支永远走不到，
+	// 会把熔断响应错当成普通业务错误返回（表现为 fallback 永远不下发）。
 	if abort != nil {
 		if abort.HasFallback() {
 			// 服务端下发了 fallback 响应：透传状态码 / headers / body
 			status := abort.GetFallbackCode()
 			fbBody := abort.GetFallbackBody()
-			rw.WriteHeader(status)
+			// 必须先写 header 再 WriteHeader：net/http 在 WriteHeader 后追加的 header 会被丢弃。
 			for k, v := range abort.GetFallbackHeaders() {
 				rw.Header().Add(k, v)
 			}
+			rw.WriteHeader(status)
 			_, _ = rw.Write([]byte(fbBody))
 			return status, fbBody
 		}
@@ -349,6 +347,13 @@ func writeResult(rw http.ResponseWriter, ret interface{}, abort *model.CallAbort
 		rw.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = rw.Write([]byte(body))
 		return http.StatusServiceUnavailable, body
+	}
+	// 非熔断的真实业务错误（abort 为 nil 但底层调用返回 err）
+	if err != nil {
+		body := fmt.Sprintf("[error] fail : %s", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		_, _ = rw.Write([]byte(body))
+		return http.StatusInternalServerError, body
 	}
 	resp, _ := ret.(commonResponse)
 	// 透传 provider 的真实状态码与 body：脚本/curl 据此能直接区分 200/5xx，

--- a/examples/circuitbreaker/test.md
+++ b/examples/circuitbreaker/test.md
@@ -116,7 +116,7 @@
 - `block_configs[0]`：
   - `error_conditions`：`RET_CODE RANGE 500~599`（4xx 不计入熔断）
   - `trigger_conditions`：`CONSECUTIVE_ERROR=5` + `ERROR_RATE 50%@30s, minRequest=10`
-- `recover_condition.sleep_window=12s`，`consecutiveSuccess=1`
+- `recover_condition.sleep_window=6s`，`consecutiveSuccess=1`
 
 ### 验证步骤
 - 1.1 复位 provider：a=200，b=500
@@ -125,7 +125,7 @@
 - ── Decorator 第 1 轮 ──
 - 1.4 触发：连发 `INSTANCE_R1_TRIGGER_COUNT=30` 次 `/echo`，让 b 累计 5 次失败 → 实例 b 被摘除
 - 1.5 验证：再发 `RECOVERY_REQUEST_COUNT`（默认 10）次，流量应全部走 a
-- 1.6 恢复：b 翻回 200，等 `WAIT_HALF_OPEN_SECONDS`（默认 15s）进半开 → b 重新加入 LB
+- 1.6 恢复：b 翻回 200，等 `WAIT_HALF_OPEN_SECONDS`（默认 8s）进半开 → b 重新加入 LB
 - ── Decorator 第 2 轮 ──
 - 1.7 再次触发：b 重新置 500，发 `INSTANCE_R2_TRIGGER_COUNT=30` 次
 - 1.8 再次验证：流量再次全部走 a
@@ -134,7 +134,7 @@
 - 1.10 启动 invokeHandler consumer（selfService 同 Decorator）
 - 1.11 触发：b=500，发 `INSTANCE_R1_TRIGGER_COUNT=30` 次
 - 1.12 验证：再发 10 次，流量全部走 a
-- 1.13 恢复：b 翻回 200，等 15s
+- 1.13 恢复：b 翻回 200，等 8s
 
 ### 通过条件（共 9 项指标）
 - Decorator 两轮 `trigger_fail >= 1`
@@ -172,13 +172,24 @@
 - 2.10 启动 invokeHandler consumer
 - 2.11 触发：a/b=500，发 `TRIGGER_REQUEST_COUNT` 次
 - 2.12 验证：再发 `RECOVERY_REQUEST_COUNT` 次，期望出现 abort
-- 2.13 恢复：a/b 翻回 200，等 15s
+- 2.13 恢复：a/b 翻回 200，等 8s
+- ── fallback 子阶段（复用 Decorator 的规则 cb-service-CircuitBreakerServiceCaller，PUT 更新规则切换 fallbackConfig.enable）──
+- 2.14 PUT 更新规则打开 `fallbackConfig.enable=true`（code=599 / body="degraded by circuitbreaker" / header X-Fallback=true）
+- 2.15 重启 consumer（规则 revision 变更触发 SDK counter 重建，需重新加载）
+- 2.16 正向触发：a/b=500，发 `TRIGGER_REQUEST_COUNT` 次 `/echo`
+- 2.17 正向验证：再发 `RECOVERY_REQUEST_COUNT` 次，期望 `CASE_FALLBACK >= 1`（HTTP 599 + body "degraded"）
+- 2.18 PUT 更新规则关闭 `fallbackConfig.enable=false`（验证 enable 短路）
+- 2.19 重启 consumer
+- 2.20 反向触发：a/b=500，发 `TRIGGER_REQUEST_COUNT` 次
+- 2.21 反向验证：再发 `RECOVERY_REQUEST_COUNT` 次，期望 `CASE_ABORT >= 1`（503，enable=false 不下发 599）
 
-### 通过条件（共 9 项指标）
+### 通过条件（共 11 项指标）
 - Decorator 两轮 `trigger_fail >= 1`
 - Decorator 两轮 `verify_abort >= 1`
 - Decorator 两轮 `recover_ok >= 1`
 - InvokeHandler `trigger_fail >= 1`，`verify_abort >= 1`，`recover_ok >= 1`
+- fallback 正向 `svc_fallback >= 1`（enable=true → HTTP 599）
+- fallback 反向 `svc_fb_off_abort >= 1`（enable=false → 503 兜底）
 
 ---
 
@@ -226,14 +237,25 @@
 - 3.15 启动 invokeHandler consumer
 - 3.16 触发：a/b=500，发 `TRIGGER_REQUEST_COUNT` 次到 `/echo`
 - 3.17 验证：再发 `RECOVERY_REQUEST_COUNT` 次，期望出现 abort
-- 3.18 恢复：a/b 翻回 200，等 15s
+- 3.18 恢复：a/b 翻回 200，等 8s
+- ── fallback 子阶段（复用 Decorator 的 merged 规则 cb-interface-CircuitBreakerInterfaceCaller，PUT 更新规则切换 fallbackConfig.enable）──
+- 3.19 PUT 更新规则打开 `fallbackConfig.enable=true`（code=599 / body="degraded by circuitbreaker"）
+- 3.20 重启 consumer（规则 revision 变更触发 SDK counter 重建，需重新加载）
+- 3.21 正向触发：a/b=500，发 `TRIGGER_REQUEST_COUNT` 次到 `/echo`
+- 3.22 正向验证：再发 `RECOVERY_REQUEST_COUNT` 次，期望 `CASE_FALLBACK >= 1`（HTTP 599 + body "degraded"，fallbackConfig 为 Rule 级字段，三个 block 共享）
+- 3.23 PUT 更新规则关闭 `fallbackConfig.enable=false`（验证 enable 短路）
+- 3.24 重启 consumer
+- 3.25 反向触发：a/b=500，发 `TRIGGER_REQUEST_COUNT` 次到 `/echo`
+- 3.26 反向验证：再发 `RECOVERY_REQUEST_COUNT` 次，期望 `CASE_ABORT >= 1`（503，enable=false 不下发 599）
 
-### 通过条件（共 14 项指标）
+### 通过条件（共 16 项指标）
 - `/echo` Decorator 两轮 trigger ≥1 fail / verify ≥1 abort / recover 全 200
 - `/order` 整批失败但 `abort == 0`
 - `/info` 整批失败但 `abort == 0`
 - `/slow` trigger 阶段成功完成 ≥1 / verify ≥1 abort / recover 全 200
 - InvokeHandler trigger ≥1 fail / verify ≥1 abort / recover ≥1 ok
+- fallback 正向 `iface_fallback >= 1`（enable=true → HTTP 599）
+- fallback 反向 `iface_fb_off_abort >= 1`（enable=false → 503 兜底）
 
 ---
 
@@ -382,7 +404,7 @@
 对 13 个 BlockConfig 各跑 3 阶段：
 - `trigger`：发 `PM_TRIGGER_COUNT=30` 次 → 触发对应 BC 熔断
 - `verify`：再发 3 次 → 期望 abort 或 ok，总计 = 3
-- `recover`：provider 翻回 200，等 15s → 再发 3 次 → 全 200
+- `recover`：provider 翻回 200，等 8s → 再发 3 次 → 全 200
 
 ### 通过条件（共 13 × 3 = 39 项指标）
 每个 BC：`trigger fail >= 1 || abort >= 1`，`verify ok + abort == 3`，`recover ok == 3`
@@ -410,7 +432,7 @@
 对 5 种 MatchString 各跑正向 3 阶段：
 - `trigger`：发 `PATHTYPE_TRIGGER_COUNT=30` 次 → 触发对应 BC 熔断
 - `verify`：再发 3 次 → 期望 abort 或 ok，总计 = 3
-- `recover`：provider 翻回 200，等 15s → 再发 3 次 → 全 200
+- `recover`：provider 翻回 200，等 8s → 再发 3 次 → 全 200
 
 ### 为什么移除了反向验证？
 5 种 path-type 已合并到 1 条规则的 5 个 BlockConfig。`NOT_EQUALS` 和 `NOT_IN` 否定匹配 BC 会吃掉几乎所有 path，不存在"对全部 5 个 BC 都不匹配"的反向 path。正向 3 阶段已充分证明 5 种 MatchString 各自的匹配语义。
@@ -467,52 +489,6 @@
 
 ---
 
-## 用例 11：自定义降级（CustomFallback）
-
-### 验证目的
-验证服务端规则配置的降级响应（`FallbackConfig`）端到端生效：熔断 OPEN 后，SDK 通过
-`CallAborted` 携带规则配置的 `code` / `body` / `headers`，demo 在 `abort.HasFallback()==true`
-时透传该降级响应，`==false`（或规则未配 fallback）时回 503 兜底。
-
-仅 **SERVICE / METHOD** 级规则支持 fallback（INSTANCE 级不支持，与 polaris-java 一致）。
-
-### Caller 写法
-| 子阶段 | level | enable | selfService | 端口 | 期望 |
-|--------|-------|--------|-------------|------|------|
-| A | SERVICE | true  | CircuitBreakerSvcFallbackCaller       | 18101 | HTTP 599 + body `degraded` |
-| B | SERVICE | false | CircuitBreakerSvcFallbackOffCaller    | 18102 | 503 `circuit breaker open` |
-| C | METHOD  | true  | CircuitBreakerMethodFallbackCaller    | 18103 | HTTP 599 + body `degraded` |
-| D | METHOD  | false | CircuitBreakerMethodFallbackOffCaller | 18104 | 503 `circuit breaker open` |
-
-四个子阶段各用独立 caller + 独立规则名，避免熔断状态残留干扰。consumer 复用
-`newCircuitBreakerCaller/consumer`（Decorator 模式），请求路径统一 `/echo`。
-
-### 规则（4 条，均持久化）
-- A `cb-service-CircuitBreakerSvcFallbackCaller`：`level=SERVICE`，`fallbackConfig.enable=true`，
-  `response.code=599`，`body="degraded by circuitbreaker"`，`headers=[X-Fallback=true]`，`CONSECUTIVE_ERROR=5`
-- B `cb-service-CircuitBreakerSvcFallbackOffCaller`：同上但 `fallbackConfig.enable=false`
-- C `cb-method-CircuitBreakerMethodFallbackCaller`：`level=METHOD`，`api.path=/echo`，`fallbackConfig.enable=true`
-- D `cb-method-CircuitBreakerMethodFallbackOffCaller`：`level=METHOD`，`api.path=/echo`，`fallbackConfig.enable=false`
-
-### 验证步骤（每个子阶段执行相同流程，单轮）
-- .1 启动 consumer（独立 selfService）
-- .2 创建规则（带/不带 fallbackConfig）
-- .3 trigger：provider-a=500 / provider-b=500，发 30 次触发熔断（50/50 LB 下 `CONSECUTIVE_ERROR=5` 需足够 burst）
-- .4 verify：再发 10 次
-  - 正向（A/C）：期望 `CASE_FALLBACK >= 1`（HTTP 599 + body `degraded`）
-  - 反向（B/D）：期望 `CASE_ABORT >= 1`（503 + `circuit breaker open`）
-
-### 通过条件
-- 4 个子阶段均满足 `trigger_fail >= 1` 且对应期望指标（fallback / abort）`>= 1`
-
-### 验证原理
-- `buildFallbackInfo`（counter.go）从规则的 `fallbackConfig` 解析 `FallbackInfo`，仅 `enable==true` 时构建
-- 熔断 `toOpen()` 时通过 `SetFallbackInfo` 注入 OPEN 状态 → `Check` 透传 → `CallAborted` 携带
-- 反向用例（B/D）专门验证 `buildFallbackInfo` 的 `GetEnable()` 短路：`enable=false` 时不返回 fallback，业务回 503
-- `run_burst` 按 HTTP 599 + body `degraded` 识别 FALLBACK，按 `circuit breaker open` 识别 ABORT
-
----
-
 ## 失败诊断
 
 每个用例失败时脚本会输出统计变量值，常见原因：
@@ -554,6 +530,7 @@
 | `FilterOnlyRouter` 全死全活兜底（`enableRecoverAll`） | 用例 10 |
 | `MakeInvokeHandler` + `AcquirePermission` 手动编排模式 | 用例 1/2/3 InvokeHandler 子阶段 + 用例 10(B) |
 | 三种调用模式行为一致性 | 用例 10（Decorator / InvokeHandler / Bare Report） |
-| `buildFallbackInfo` 解析规则降级响应（SERVICE/METHOD） | 用例 11 A/C |
-| `buildFallbackInfo` 的 `GetEnable()` 短路（enable=false 回 503） | 用例 11 B/D |
-| `CallAborted` 携带 fallback + demo `HasFallback()` 透传 | 用例 11 全部 |
+| `buildFallbackInfo` 解析规则降级响应（SERVICE/METHOD） | 用例 2/3 fallback 正向子阶段 |
+| `buildFallbackInfo` 的 `GetEnable()` 短路（enable=false 回 503） | 用例 2/3 fallback 反向子阶段 |
+| `CallAborted` 携带 fallback + demo `HasFallback()` 透传/回退 | 用例 2/3 fallback 子阶段 |
+| PUT 更新熔断规则 fallbackConfig.enable 触发 SDK counter 重建 | 用例 2/3 fallback 子阶段 |

--- a/examples/circuitbreaker/test.md
+++ b/examples/circuitbreaker/test.md
@@ -441,7 +441,7 @@
 ### 规则
 - `level=INSTANCE`，`name=cb-instance-CircuitBreakerHttpStatusCaller`，`source=*/*`（通配所有 caller）
 - `CONSECUTIVE_ERROR=3`（收紧阈值加快验证）
-- `recover_condition.sleep_window=12s`，`consecutiveSuccess=1`
+- `recover_condition.sleep_window=6s`，`consecutiveSuccess=1`
 
 ### 验证步骤（每个子阶段执行相同流程）
 - ── 全死全活开启 ──
@@ -464,6 +464,52 @@
 - INSTANCE 级熔断不经过 `AcquirePermission`（只检查 SERVICE/METHOD 级），请求可透传至 provider
 - 全死全活触发时 FilterOnlyRouter 设置 `HasLimitedInstances=true`，LB 从 `selectableInstancesWithoutUnhealthy` 中选择 OPEN 实例
 - 全死全活关闭时 LB 从 `healthyInstances`（空集）中选择 → `GetOneInstance` 失败
+
+---
+
+## 用例 11：自定义降级（CustomFallback）
+
+### 验证目的
+验证服务端规则配置的降级响应（`FallbackConfig`）端到端生效：熔断 OPEN 后，SDK 通过
+`CallAborted` 携带规则配置的 `code` / `body` / `headers`，demo 在 `abort.HasFallback()==true`
+时透传该降级响应，`==false`（或规则未配 fallback）时回 503 兜底。
+
+仅 **SERVICE / METHOD** 级规则支持 fallback（INSTANCE 级不支持，与 polaris-java 一致）。
+
+### Caller 写法
+| 子阶段 | level | enable | selfService | 端口 | 期望 |
+|--------|-------|--------|-------------|------|------|
+| A | SERVICE | true  | CircuitBreakerSvcFallbackCaller       | 18101 | HTTP 599 + body `degraded` |
+| B | SERVICE | false | CircuitBreakerSvcFallbackOffCaller    | 18102 | 503 `circuit breaker open` |
+| C | METHOD  | true  | CircuitBreakerMethodFallbackCaller    | 18103 | HTTP 599 + body `degraded` |
+| D | METHOD  | false | CircuitBreakerMethodFallbackOffCaller | 18104 | 503 `circuit breaker open` |
+
+四个子阶段各用独立 caller + 独立规则名，避免熔断状态残留干扰。consumer 复用
+`newCircuitBreakerCaller/consumer`（Decorator 模式），请求路径统一 `/echo`。
+
+### 规则（4 条，均持久化）
+- A `cb-service-CircuitBreakerSvcFallbackCaller`：`level=SERVICE`，`fallbackConfig.enable=true`，
+  `response.code=599`，`body="degraded by circuitbreaker"`，`headers=[X-Fallback=true]`，`CONSECUTIVE_ERROR=5`
+- B `cb-service-CircuitBreakerSvcFallbackOffCaller`：同上但 `fallbackConfig.enable=false`
+- C `cb-method-CircuitBreakerMethodFallbackCaller`：`level=METHOD`，`api.path=/echo`，`fallbackConfig.enable=true`
+- D `cb-method-CircuitBreakerMethodFallbackOffCaller`：`level=METHOD`，`api.path=/echo`，`fallbackConfig.enable=false`
+
+### 验证步骤（每个子阶段执行相同流程，单轮）
+- .1 启动 consumer（独立 selfService）
+- .2 创建规则（带/不带 fallbackConfig）
+- .3 trigger：provider-a=500 / provider-b=500，发 30 次触发熔断（50/50 LB 下 `CONSECUTIVE_ERROR=5` 需足够 burst）
+- .4 verify：再发 10 次
+  - 正向（A/C）：期望 `CASE_FALLBACK >= 1`（HTTP 599 + body `degraded`）
+  - 反向（B/D）：期望 `CASE_ABORT >= 1`（503 + `circuit breaker open`）
+
+### 通过条件
+- 4 个子阶段均满足 `trigger_fail >= 1` 且对应期望指标（fallback / abort）`>= 1`
+
+### 验证原理
+- `buildFallbackInfo`（counter.go）从规则的 `fallbackConfig` 解析 `FallbackInfo`，仅 `enable==true` 时构建
+- 熔断 `toOpen()` 时通过 `SetFallbackInfo` 注入 OPEN 状态 → `Check` 透传 → `CallAborted` 携带
+- 反向用例（B/D）专门验证 `buildFallbackInfo` 的 `GetEnable()` 短路：`enable=false` 时不返回 fallback，业务回 503
+- `run_burst` 按 HTTP 599 + body `degraded` 识别 FALLBACK，按 `circuit breaker open` 识别 ABORT
 
 ---
 
@@ -508,3 +554,6 @@
 | `FilterOnlyRouter` 全死全活兜底（`enableRecoverAll`） | 用例 10 |
 | `MakeInvokeHandler` + `AcquirePermission` 手动编排模式 | 用例 1/2/3 InvokeHandler 子阶段 + 用例 10(B) |
 | 三种调用模式行为一致性 | 用例 10（Decorator / InvokeHandler / Bare Report） |
+| `buildFallbackInfo` 解析规则降级响应（SERVICE/METHOD） | 用例 11 A/C |
+| `buildFallbackInfo` 的 `GetEnable()` 短路（enable=false 回 503） | 用例 11 B/D |
+| `CallAborted` 携带 fallback + demo `HasFallback()` 透传 | 用例 11 全部 |

--- a/examples/circuitbreaker/test.md
+++ b/examples/circuitbreaker/test.md
@@ -54,6 +54,73 @@
 
 用例 1/2/3 的 Decorator 和 InvokeHandler 子阶段**共用同一个 selfService 和熔断规则**（Decorator recover 后规则完全恢复，InvokeHandler 重新 trigger）。
 
+## SDK 日志目录映射
+
+每次 consumer 启动时会在 `.build/<consumer_name>_run/` 下创建独立的 Polaris SDK 日志目录。
+每个 `_run` 目录的结构如下（以 `instance_consumer_run` 为例）：
+
+```
+.build/instance_consumer_run/polaris/log/
+├── auth/polaris-auth.log
+├── base/polaris.log                         ← 通用日志（版本号、连接状态）
+├── cache/polaris-cache.log
+├── circuitbreaker/polaris-circuitbreaker.log ← 熔断器日志（核心排查日志）
+├── lossless/polaris-lossless.log
+├── network/polaris-network.log
+├── route/polaris-route.log
+└── statReport/polaris-statReport.log
+```
+
+> **排查熔断问题时，优先看 `polaris-circuitbreaker.log`**（poleis-stat.log 已不再输出熔断日志）。
+> 该日志包含规则加载（`ruleName`/`ruleID`/`ruleRev`）、计数器初始化、状态切换（`close → open → half-open → close`）等完整链路信息。
+
+### 各用例对应的 `.build/` 目录
+
+| 用例 | 子阶段 | `.build/` 目录 |
+|------|--------|---------------|
+| 1 | Decorator | `instance_consumer_run/` |
+| 1 | InvokeHandler | `instance_invoke_consumer_run/` |
+| 2 | Decorator | `service_consumer_run/` |
+| 2 | InvokeHandler | `service_invoke_consumer_run/` |
+| 2 | fallback 正向 | `service_fallback_consumer_run/` |
+| 2 | fallback 反向 | `service_fallback_off_consumer_run/` |
+| 3 | Decorator | `interface_consumer_run/` |
+| 3 | InvokeHandler | `interface_invoke_consumer_run/` |
+| 3 | fallback 正向 | `interface_fallback_consumer_run/` |
+| 3 | fallback 反向 | `interface_fallback_off_consumer_run/` |
+| 4 | - | `old_instance_consumer_run/` |
+| 5 | A/B/C 段（共用 consumer） | `http_status_consumer_run/` |
+| 6 | - | `default_rule_consumer_run/` |
+| 7 | - | `modify_rule_consumer_run/` |
+| 8 | - | `pm_consumer_run/` |
+| 9 | - | `pathtype_consumer_run/` |
+| 10 | A Decorator | `decorator_consumer_run/` `decorator_consumer_b_run/` `decorator_consumer_c_run/` |
+| 10 | B InvokeHandler | `invoke_consumer_run/` `invoke_consumer_b_run/` `invoke_consumer_c_run/` |
+| 10 | C Bare Report | `report_consumer_run/` `report_consumer_b_run/` `report_consumer_c_run/` |
+| - | provider-a | `provider_a_run/` |
+| - | provider-b | `provider_b_run/` |
+
+> 用例 10 的三个子阶段各重启 consumer 三次（enableRecoverAll=true → false → true），
+> `_run` 为第一次启动（全死全活开启），`_b_run` 为第二次启动（全死全活关闭），
+> `_c_run` 为第三次启动（恢复全死全活开启）。
+
+### 排查示例
+
+```bash
+# 查看用例 5 B 段失败时 SDK 的熔断规则加载和状态切换
+grep -E "rule|counter|OPEN|close|half" \
+  .build/http_status_consumer_run/polaris/log/circuitbreaker/polaris-circuitbreaker.log
+
+# 查看用例 10 Decorator 子阶段全死全活关闭时的实例选择
+grep -E "instance|healthy|isolated|fallback" \
+  .build/decorator_consumer_b_run/polaris/log/base/polaris.log
+
+# 查看 provider 端日志
+cat .build/provider_b_run/polaris/log/base/polaris.log
+```
+
+
+
 ## Provider 暴露的接口
 
 | 路径    | 默认行为                | 控制开关                                      | 用途                                        |
@@ -491,7 +558,7 @@
 
 ## 失败诊断
 
-每个用例失败时脚本会输出统计变量值，常见原因：
+各用例对应的 SDK 日志目录见上方「SDK 日志目录映射」章节。每个用例失败时脚本会输出统计变量值，常见原因：
 
 | 现象 | 可能原因 | 排查 |
 |------|---------|------|

--- a/examples/circuitbreaker/verify_circuitbreaker.sh
+++ b/examples/circuitbreaker/verify_circuitbreaker.sh
@@ -2991,6 +2991,19 @@ case_http_status() {
 
     stop_consumer "$consumer_pid"
 
+    # ── 禁用 SERVICE 级规则，避免残留干扰下次运行的 B 段 ──
+    # Polaris 控制台 DELETE 接口始终返回 403，无法直接删除规则。
+    # 在 C 段结束后通过 PUT enable=false 达到同等隔离：
+    #   下次 B 段 trigger 时 SERVICE 规则已 disabled，不会同时 OPEN 并阻断 recover。
+    log_step "用例5.11 禁用 SERVICE 级规则（PUT enable=false，避免残留干扰下次 B段）"
+    local svc_disable_body
+    svc_disable_body=$(echo "$svc_rule_body" | python3 -c 'import sys,json; r=json.load(sys.stdin); r["enable"]=False; print(json.dumps(r))' 2>/dev/null || echo "")
+    if [[ -n "$svc_disable_body" ]]; then
+        update_circuitbreaker_rule "http_status_service_disable" "$svc_rule_id" "$svc_disable_body" || true
+    else
+        log_error "[用例5.11] 拼装禁用 body 失败（非致命）"
+    fi
+
     # ── 判定 ──
     # A 段：4xx 全部 fail 但 abort==0（关键：abort 必须为 0，证明 4xx 没被熔断）
     # B 段：trigger 至少 3 次 5xx fail；verify 阶段 10 OK 或 10 abort 都算通过——

--- a/examples/circuitbreaker/verify_circuitbreaker.sh
+++ b/examples/circuitbreaker/verify_circuitbreaker.sh
@@ -3623,7 +3623,7 @@ _run_all_dead_phase() {
     local rule_builder="$6"
 
     # ── 全死全活开启 ──
-    log_step "[${phase_label}.1] 启动 consumer（enableRecoverAll=true）"
+    log_step "用例10 [${phase_label}.1] 启动 consumer（enableRecoverAll=true）"
     if ! start_consumer "${phase_label}_consumer" "$consumer_dir" \
         "$caller" "$port" "$log_file" "false" "true"; then
         return 1
@@ -3639,25 +3639,25 @@ _run_all_dead_phase() {
         return 1
     fi
 
-    log_step "[${phase_label}.2] 创建 INSTANCE 级熔断规则"
+    log_step "用例10 [${phase_label}.2] 创建 INSTANCE 级熔断规则"
     local rule_body rule_id
     rule_body=$($rule_builder)
     rule_id=$(create_circuitbreaker_rule "${phase_label}" "$rule_body") || {
-        log_error "[${phase_label}.2] 规则创建失败"
+        log_error "用例10 [${phase_label}.2] 规则创建失败"
         stop_consumer "$consumer_pid"
         return 1
     }
     sleep "$WAIT_RULE_READY_SECONDS"
 
     # trigger: 两个 provider 都 500，发 60 次让两个实例都被熔断 OPEN
-    log_step "[${phase_label}.3] trigger: a/b=500, 发 60 次让两个实例都被熔断"
+    log_step "用例10 [${phase_label}.3] trigger: a/b=500, 发 60 次让两个实例都被熔断"
     provider_set_error "$PROVIDER_A_PORT" "true"
     provider_set_error "$PROVIDER_B_PORT" "true"
     run_burst "$port" "60" "${phase_label}触发"
     local a_trigger_fail=$CASE_FAIL
 
     # verify: provider 翻回 200，全死全活开启 → 请求透传到 provider → 200
-    log_step "[${phase_label}.4] verify: a/b 翻回 200，验证全死全活生效"
+    log_step "用例10 [${phase_label}.4] verify: a/b 翻回 200，验证全死全活生效"
     provider_set_error "$PROVIDER_A_PORT" "false"
     provider_set_error "$PROVIDER_B_PORT" "false"
     sleep 1
@@ -3665,13 +3665,13 @@ _run_all_dead_phase() {
     local a_verify_ok=$CASE_OK
 
     # recover
-    log_step "[${phase_label}.5] recover: 等 ${WAIT_HALF_OPEN_SECONDS}s"
+    log_step "用例10 [${phase_label}.5] recover: 等 ${WAIT_HALF_OPEN_SECONDS}s"
     sleep "$WAIT_HALF_OPEN_SECONDS"
     run_burst "$port" "$RECOVERY_REQUEST_COUNT" "${phase_label}恢复"
     local a_recover_ok=$CASE_OK
 
     # ── 全死全活关闭 ──
-    log_step "[${phase_label}.6] 重启 consumer（enableRecoverAll=false）"
+    log_step "用例10 [${phase_label}.6] 重启 consumer（enableRecoverAll=false）"
     stop_consumer "$consumer_pid"
     sleep 1
     if ! start_consumer "${phase_label}_consumer_b" "$consumer_dir" \
@@ -3681,7 +3681,7 @@ _run_all_dead_phase() {
     consumer_pid="$_STARTED_PID"
 
     # 重新触发熔断
-    log_step "[${phase_label}.7] trigger: a/b=500, 发 60 次重新触发熔断"
+    log_step "用例10 [${phase_label}.7] trigger: a/b=500, 发 60 次重新触发熔断"
     provider_set_error "$PROVIDER_A_PORT" "true"
     provider_set_error "$PROVIDER_B_PORT" "true"
     run_burst "$port" "60" "${phase_label}触发B"
@@ -3694,12 +3694,12 @@ _run_all_dead_phase() {
     # 200 而恢复，verify 变成全 200，预期的 b_verify_fail 落空。保持 500 则即使进半开
     # 探测也会失败重新 OPEN，验证结果稳定且与 sleepWindow/burst 耗时无关。
     # provider 翻回 200 属于 B.9 recover 阶段的职责。
-    log_step "[${phase_label}.8] verify: 保持 a/b=500，验证全死全活关闭时实例不可选"
+    log_step "用例10 [${phase_label}.8] verify: 保持 a/b=500，验证全死全活关闭时实例不可选"
     run_burst "$port" "$RECOVERY_REQUEST_COUNT" "${phase_label}验证B"
     local b_verify_fail=$CASE_FAIL
 
     # recover: 把 provider 翻回 200（B.8 不再负责复位），重启 consumer 恢复 enableRecoverAll=true
-    log_step "[${phase_label}.9] recover: a/b 翻回 200，重启 consumer（恢复 enableRecoverAll=true）"
+    log_step "用例10 [${phase_label}.9] recover: a/b 翻回 200，重启 consumer（恢复 enableRecoverAll=true）"
     provider_set_error "$PROVIDER_A_PORT" "false"
     provider_set_error "$PROVIDER_B_PORT" "false"
     stop_consumer "$consumer_pid"
@@ -3722,10 +3722,10 @@ _run_all_dead_phase() {
         && [[ "$b_trigger_fail" -ge 5 ]] \
         && [[ "$b_verify_fail" -ge 1 ]] \
         && [[ "$b_recover_ok" -ge 1 ]]; then
-        log_info "✅ [${phase_label}] PASS: A[trigger=$a_trigger_fail verify=$a_verify_ok recover=$a_recover_ok] B[trigger=$b_trigger_fail verify=$b_verify_fail recover=$b_recover_ok]"
+        log_info "✅ 用例10 [${phase_label}] PASS: A[trigger=$a_trigger_fail verify=$a_verify_ok recover=$a_recover_ok] B[trigger=$b_trigger_fail verify=$b_verify_fail recover=$b_recover_ok]"
         return 0
     fi
-    log_error "❌ [${phase_label}] FAIL: A[trigger=$a_trigger_fail verify=$a_verify_ok recover=$a_recover_ok] B[trigger=$b_trigger_fail verify=$b_verify_fail recover=$b_recover_ok]"
+    log_error "❌ 用例10 [${phase_label}] FAIL: A[trigger=$a_trigger_fail verify=$a_verify_ok recover=$a_recover_ok] B[trigger=$b_trigger_fail verify=$b_verify_fail recover=$b_recover_ok]"
     return 1
 }
 

--- a/examples/circuitbreaker/verify_circuitbreaker.sh
+++ b/examples/circuitbreaker/verify_circuitbreaker.sh
@@ -94,6 +94,10 @@ ALL_DEAD_DECORATOR_CALLER="${ALL_DEAD_DECORATOR_CALLER:-CircuitBreakerAllDeadDec
 ALL_DEAD_INVOKE_CALLER="${ALL_DEAD_INVOKE_CALLER:-CircuitBreakerAllDeadInvokeCaller}"
 ALL_DEAD_REPORT_CALLER="${ALL_DEAD_REPORT_CALLER:-CircuitBreakerAllDeadReportCaller}"
 
+# 自定义降级（fallback）验证已合并进用例2（SERVICE）/用例3（METHOD）末尾的子阶段：
+# 复用各自的 cb-service / cb-interface 规则，PUT 切换 fallbackConfig.enable 验证正向(599)+反向(503)，
+# 不再使用独立 caller / 独立规则。
+
 # 端口规划（避免冲突）：
 #   provider-a: 28081
 #   provider-b: 28082
@@ -125,6 +129,8 @@ PATHTYPE_CONSUMER_PORT="${PATHTYPE_CONSUMER_PORT:-18089}"
 ALL_DEAD_DECORATOR_PORT="${ALL_DEAD_DECORATOR_PORT:-18090}"
 ALL_DEAD_INVOKE_PORT="${ALL_DEAD_INVOKE_PORT:-18091}"
 ALL_DEAD_REPORT_PORT="${ALL_DEAD_REPORT_PORT:-18092}"
+# 注：fallback 验证复用用例2/3 的 consumer 端口（SERVICE_CONSUMER_PORT / INTERFACE_CONSUMER_PORT），
+# 不再单独分配端口。
 
 # 触发熔断所需的请求次数（单实例失败计数）
 # 默认实例熔断规则：连续错误数 / 错误率，10 次足够触发
@@ -132,11 +138,11 @@ TRIGGER_REQUEST_COUNT="${TRIGGER_REQUEST_COUNT:-15}"
 # 验证恢复时的请求次数
 RECOVERY_REQUEST_COUNT="${RECOVERY_REQUEST_COUNT:-10}"
 # 等待 SDK 拉取规则 + 缓存就绪的秒数
-WAIT_RULE_READY_SECONDS="${WAIT_RULE_READY_SECONDS:-8}"
+WAIT_RULE_READY_SECONDS="${WAIT_RULE_READY_SECONDS:-5}"
 # 等待熔断 sleepWindow 后进入半开（与下方规则模板的 sleep_window 配合）
 # 用例需要执行两轮"触发→熔断→恢复"，把等待时长压短可显著减少端到端耗时；
-# sleepWindow 由 _gen_rule.py 写为 12s，这里多给 3s buffer。
-WAIT_HALF_OPEN_SECONDS="${WAIT_HALF_OPEN_SECONDS:-15}"
+# sleepWindow 由 _gen_rule.py 写为 6s，这里多给 2s buffer。
+WAIT_HALF_OPEN_SECONDS="${WAIT_HALF_OPEN_SECONDS:-8}"
 
 # 默认运行的子用例集合（逗号分隔），可通过 --only 缩小范围
 RUN_CASES="${RUN_CASES:-instance,service,interface,old_instance,http_status,default_rule,modify_rule,protocol_method,pathtype,all_dead_fallback}"
@@ -536,6 +542,7 @@ def strip_semantic(d):
         'triggerCondition', 'trigger_condition',
         'recoverCondition', 'recover_condition',
         'blockConfigs', 'block_configs',
+        'fallbackConfig', 'fallback_config',
     }
     res = {k: v for k, v in d.items() if k in wanted}
     # ruleMatcher.destination.method 字段已 deprecated，匹配语义改由
@@ -848,7 +855,7 @@ enable_circuitbreaker_rule() {
 #     避免不同 case 之间相互触发。
 #   - block_configs 仅一个，trigger_conditions = ERROR_RATE 50%/30s/minimumRequest=10
 #     + CONSECUTIVE_ERROR=5；error_conditions = retCode 5xx
-#   - recover_condition.sleepWindow = 30s，consecutiveSuccess = 1（只要 1 次成功即恢复）
+#   - recover_condition.sleepWindow = 6s，consecutiveSuccess = 1（只要 1 次成功即恢复）
 
 # 用例1 Decorator 子阶段
 build_rule_body_instance() {
@@ -943,12 +950,55 @@ build_rule_body_http_status_service() {
 }
 
 # 用例2 Decorator 子阶段
+# 显式写 FALLBACK_ENABLE=false：本用例的 abort 子阶段（2.4~2.13）期望熔断 OPEN 回 503/ABORT，
+# 不应出现 fallback。而 fallback 子阶段（2.14~2.21）会把同一条规则 PUT 成 enable=true，跑完若
+# 不复位，下次运行 2.3 创建时会因服务端残留 fallbackConfig.enable=true 而误出 HTTP 599。基线
+# 显式带 enable=false 后，circuitbreaker_rule_needs_update 能检测到残留的 enable=true 差异并
+# 触发 PUT 复位（依赖 strip_semantic 的 wanted 已纳入 fallbackConfig）。
 build_rule_body_service() {
     NAMESPACE="$NAMESPACE" SERVICE_NAME="$SERVICE_NAME" \
         SOURCE_NAMESPACE="$NAMESPACE" SOURCE_SERVICE="$SERVICE_CALLER" \
         RULE_NAME="cb-service-${SERVICE_CALLER}" \
         LEVEL="SERVICE" \
         BC_NAME="service-block" \
+        FALLBACK_ENABLE="false" \
+        FALLBACK_CODE="599" \
+        FALLBACK_BODY="degraded by circuitbreaker" \
+        FALLBACK_HEADERS="X-Fallback=true" \
+        python3 "${SCRIPT_DIR}/.build/_gen_rule.py"
+}
+
+# 用例2 fallback 子阶段：在 cb-service-${SERVICE_CALLER} 原规则基础上打开自定义降级。
+# 规则名 / level / source 与 build_rule_body_service 完全一致，仅顶层追加 fallbackConfig
+# (enable=true, code=599, body 含 degraded, header X-Fallback=true)，通过 PUT 更新已有规则。
+# 熔断 OPEN 后 SDK 经 CallAborted 透传该降级响应，demo 在 HasFallback()==true 时回 599+body。
+build_rule_body_service_fallback_on() {
+    NAMESPACE="$NAMESPACE" SERVICE_NAME="$SERVICE_NAME" \
+        SOURCE_NAMESPACE="$NAMESPACE" SOURCE_SERVICE="$SERVICE_CALLER" \
+        RULE_NAME="cb-service-${SERVICE_CALLER}" \
+        LEVEL="SERVICE" \
+        BC_NAME="service-block" \
+        FALLBACK_ENABLE="true" \
+        FALLBACK_CODE="599" \
+        FALLBACK_BODY="degraded by circuitbreaker" \
+        FALLBACK_HEADERS="X-Fallback=true" \
+        python3 "${SCRIPT_DIR}/.build/_gen_rule.py"
+}
+
+# 用例2 fallback 反向子阶段：把已打开的自定义降级再 PUT 关闭（enable=false）。
+# 验证 buildFallbackInfo 的 enable 短路——fallbackConfig 存在但 enable=false 时不下发降级，
+# 熔断 OPEN 的响应回退为 ABORT(503 "circuit breaker open")。规则名/level/source 不变，仅
+# fallbackConfig.enable 翻为 false（response 内容保留但不应被透传，用于验证 enable 才是权威信号）。
+build_rule_body_service_fallback_off() {
+    NAMESPACE="$NAMESPACE" SERVICE_NAME="$SERVICE_NAME" \
+        SOURCE_NAMESPACE="$NAMESPACE" SOURCE_SERVICE="$SERVICE_CALLER" \
+        RULE_NAME="cb-service-${SERVICE_CALLER}" \
+        LEVEL="SERVICE" \
+        BC_NAME="service-block" \
+        FALLBACK_ENABLE="false" \
+        FALLBACK_CODE="599" \
+        FALLBACK_BODY="should-not-appear" \
+        FALLBACK_HEADERS="X-Fallback=true" \
         python3 "${SCRIPT_DIR}/.build/_gen_rule.py"
 }
 
@@ -1005,6 +1055,9 @@ bcs.append({
 })
 print(json.dumps(bcs))
 ')
+    # 显式 FALLBACK_ENABLE=false：理由同 build_rule_body_service——fallback 子阶段会把本规则
+    # PUT 成 enable=true，基线带 enable=false 才能让 needs_update 检测残留并复位，避免 abort 子
+    # 阶段误出 HTTP 599。
     NAMESPACE="$NAMESPACE" SERVICE_NAME="$SERVICE_NAME" \
         SOURCE_NAMESPACE="$NAMESPACE" SOURCE_SERVICE="$INTERFACE_CALLER" \
         RULE_NAME="cb-interface-${INTERFACE_CALLER}" \
@@ -1015,7 +1068,94 @@ print(json.dumps(bcs))
         ERROR_PERCENT="50" \
         ERROR_INTERVAL="30" \
         MINIMUM_REQUEST="10" \
+        FALLBACK_ENABLE="false" \
+        FALLBACK_CODE="599" \
+        FALLBACK_BODY="degraded by circuitbreaker" \
+        FALLBACK_HEADERS="X-Fallback=true" \
         python3 "${SCRIPT_DIR}/.build/_gen_rule.py"
+}
+
+# 用例3 fallback 子阶段：在 cb-interface-${INTERFACE_CALLER} 原 merged 规则基础上打开自定义降级。
+# 复用 build_rule_body_interface_merged 的三个 BlockConfig（echo/order/slow），结构完全一致，
+# 仅在规则顶层追加 fallbackConfig——fallbackConfig 是 Rule 级（非 BlockConfig 级）字段，整条规则
+# 共享，任一 block 熔断 OPEN 时 SDK 都经 CallAborted 透传该降级响应。通过 PUT 更新已有规则。
+# _build_rule_body_interface_fallback <enable> <body>
+# 复用 build_rule_body_interface_merged 的三个 BlockConfig（echo/order/slow），在规则顶层注入
+# fallbackConfig（enable 由 $1 控制）。on/off 两个对外 builder 都委托到这里，避免重复 BCS 定义。
+#   $1 = "true"  → 打开降级，熔断 OPEN 后透传 HTTP 599 + body
+#   $1 = "false" → enable 短路，fallbackConfig 存在但不下发，熔断 OPEN 回退为 503/ABORT
+_build_rule_body_interface_fallback() {
+    local fb_enable="$1"
+    local fb_body="$2"
+    local bcs
+    bcs=$(python3 -c '
+import json
+bcs = []
+echo_err = [
+    {"inputType":"RET_CODE","condition":{"type":"RANGE","value":"500~599"}},
+    {"inputType":"RET_CODE","condition":{"type":"EXACT","value":"500"}},
+    {"inputType":"RET_CODE","condition":{"type":"REGEX","value":"^5[0-9]{2}$"}},
+    {"inputType":"RET_CODE","condition":{"type":"IN","value":"500,502,503,504"}},
+    {"inputType":"RET_CODE","condition":{"type":"NOT_IN","value":"200,201,204,400,401,403,404"}},
+]
+bcs.append({
+    "name": "echo-block",
+    "api": {"protocol": "*", "method": "*", "path": {"type": "EXACT", "value": "/echo"}},
+    "error_conditions": echo_err,
+    "trigger_conditions": [
+        {"triggerType": "CONSECUTIVE_ERROR", "errorCount": 5},
+        {"triggerType": "ERROR_RATE", "errorPercent": 50, "interval": 30, "minimumRequest": 10},
+    ],
+})
+bcs.append({
+    "name": "order-block",
+    "api": {"protocol": "*", "method": "*", "path": {"type": "EXACT", "value": "/order"}},
+    "error_conditions": [
+        {"inputType": "RET_CODE", "condition": {"type": "RANGE", "value": "500~599"}},
+    ],
+    "trigger_conditions": [
+        {"triggerType": "CONSECUTIVE_ERROR", "errorCount": 100},
+        {"triggerType": "ERROR_RATE", "errorPercent": 99, "interval": 30, "minimumRequest": 200},
+    ],
+})
+bcs.append({
+    "name": "slow-block",
+    "api": {"protocol": "*", "method": "*", "path": {"type": "EXACT", "value": "/slow"}},
+    "error_conditions": [
+        {"inputType": "DELAY", "condition": {"type": "EXACT", "value": "200"}},
+    ],
+    "trigger_conditions": [
+        {"triggerType": "CONSECUTIVE_ERROR", "errorCount": 5},
+        {"triggerType": "ERROR_RATE", "errorPercent": 50, "interval": 30, "minimumRequest": 10},
+    ],
+})
+print(json.dumps(bcs))
+')
+    NAMESPACE="$NAMESPACE" SERVICE_NAME="$SERVICE_NAME" \
+        SOURCE_NAMESPACE="$NAMESPACE" SOURCE_SERVICE="$INTERFACE_CALLER" \
+        RULE_NAME="cb-interface-${INTERFACE_CALLER}" \
+        LEVEL="METHOD" \
+        BC_NAME="echo-block" \
+        BCS="$bcs" \
+        CONSECUTIVE_ERROR="5" \
+        ERROR_PERCENT="50" \
+        ERROR_INTERVAL="30" \
+        MINIMUM_REQUEST="10" \
+        FALLBACK_ENABLE="$fb_enable" \
+        FALLBACK_CODE="599" \
+        FALLBACK_BODY="$fb_body" \
+        FALLBACK_HEADERS="X-Fallback=true" \
+        python3 "${SCRIPT_DIR}/.build/_gen_rule.py"
+}
+
+# 用例3 fallback 正向：打开自定义降级，熔断 OPEN 后透传 HTTP 599 + "degraded"
+build_rule_body_interface_fallback_on() {
+    _build_rule_body_interface_fallback "true" "degraded by circuitbreaker"
+}
+
+# 用例3 fallback 反向：关闭自定义降级（enable=false），验证 enable 短路 → 熔断 OPEN 回 503/ABORT
+build_rule_body_interface_fallback_off() {
+    _build_rule_body_interface_fallback "false" "should-not-appear"
 }
 
 # 用例3 InvokeHandler 子阶段：简化 METHOD 级规则，只验证 /echo 路径
@@ -1301,6 +1441,9 @@ consecutive_error = int(os.environ.get('CONSECUTIVE_ERROR', '5'))
 error_percent = int(os.environ.get('ERROR_PERCENT', '50'))
 error_interval = int(os.environ.get('ERROR_INTERVAL', '30'))
 minimum_request = int(os.environ.get('MINIMUM_REQUEST', '10'))
+# sleepWindow 默认 6s（压缩耗时）；用例10（全死全活）等"trigger 后需在 OPEN 窗口内立即 verify"
+# 的用例可通过 SLEEP_WINDOW 单独设大值，避免 60 次 burst 耗时超过窗口导致实例提前半开恢复。
+sleep_window = int(os.environ.get('SLEEP_WINDOW', '6'))
 
 # 触发条件：CONSECUTIVE_ERROR + ERROR_RATE，两者满足任一即触发熔断。
 trigger_conditions = [
@@ -1385,12 +1528,32 @@ rule = {
     'error_conditions': err_conditions,
     'trigger_condition': trigger_conditions,
     'recoverCondition': {
-        # sleepWindow 设小一点，便于一轮用例里跑两次"触发→熔断→恢复"。
-        'sleep_window': 12,
+        # sleepWindow 设小一点，便于一轮用例里跑两次"触发→熔断→恢复"，并压缩端到端耗时。
+        # 默认 6s，可由 SLEEP_WINDOW 环境变量覆盖（用例10 全死全活需更大窗口）。
+        'sleep_window': sleep_window,
         'consecutiveSuccess': 1,
     },
     'block_configs': bcs,
 }
+
+# 自定义降级（fallback）：仅当传入 FALLBACK_ENABLE 时才写 fallback_config，
+# 未传则完全不写，保证既有用例的规则体零变化。
+# FALLBACK_HEADERS 形如 "k1=v1,k2=v2"，按 = 分割（value 允许含 = 用 split 限 1 次）。
+fb_enable = os.environ.get('FALLBACK_ENABLE', '')
+if fb_enable != '':
+    fb_headers = []
+    for kv in os.environ.get('FALLBACK_HEADERS', '').split(','):
+        if '=' in kv:
+            k, v = kv.split('=', 1)
+            fb_headers.append({'key': k, 'value': v})
+    rule['fallbackConfig'] = {
+        'enable': fb_enable.lower() == 'true',
+        'response': {
+            'code': int(os.environ.get('FALLBACK_CODE', '599')),
+            'body': os.environ.get('FALLBACK_BODY', 'degraded by circuitbreaker'),
+            'headers': fb_headers,
+        },
+    }
 
 sys.stdout.write(json.dumps(rule))
 PYEOF
@@ -1423,7 +1586,7 @@ generate_consumer_polaris_yaml() {
         # 启用默认规则时收紧阈值，加快端到端验证速度：
         #   - defaultErrorCount=3：连续 3 次 5xx 即触发实例级熔断
         #   - defaultMinimumRequest=3：错误率统计的最小请求数也调到 3
-        #   - sleepWindow=12s：与其它用例的规则模板保持一致
+        #   - sleepWindow=6s：与其它用例的规则模板保持一致
         #   - successCountAfterHalfOpen=1：半开 1 次成功即恢复
         # 默认 errorCondition 为 RANGE 500~599（写在 default.go 中），4xx 不计入
         default_block=$(cat <<'YAML'
@@ -1432,7 +1595,7 @@ generate_consumer_polaris_yaml() {
     defaultErrorPercent: 50
     defaultInterval: 30s
     defaultMinimumRequest: 3
-    sleepWindow: 12s
+    sleepWindow: 6s
     successCountAfterHalfOpen: 1
 YAML
 )
@@ -1634,8 +1797,8 @@ do_request() {
     echo "${http_code}|${body}"
 }
 
-# 累计请求次数 + 统计 200 / 5xx / 熔断（call aborted）三类
-# 输出全局变量：CASE_TOTAL CASE_OK CASE_FAIL CASE_ABORT
+# 累计请求次数 + 统计 200 / 5xx / 熔断（call aborted）/ 降级（fallback）四类
+# 输出全局变量：CASE_TOTAL CASE_OK CASE_FAIL CASE_ABORT CASE_FALLBACK
 run_burst() {
     local consumer_port="$1"
     local count="$2"
@@ -1646,6 +1809,7 @@ run_burst() {
     CASE_OK=0
     CASE_FAIL=0
     CASE_ABORT=0
+    CASE_FALLBACK=0
 
     # 注意：`run_burst` 通常被 case_instance/case_service/case_interface 间接调用，
     # 而调用方用 `r=$(case_xxx)` 通过命令替换捕获用例结论 (PASS/FAIL)。
@@ -1665,16 +1829,25 @@ run_burst() {
         short_body=$(echo "$body" | head -c 80)
 
         # 判定优先级（从高到低）：
-        #   1) ABORT —— body 命中 "call aborted"，说明 polaris-go 拦截了调用
-        #   2) FAIL  —— 上游返回非 200，或 consumer 透传了 provider 的 5xx 状态
-        #               注意：当前 demo 中 consumer 在 provider 5xx 时仍 WriteHeader(200)，
-        #               把原 body（含 "status code: 500, Fatal, ..."）原样回写，因此必须
-        #               同时检测 body 中的 5xx 提示，避免把失败错算成 OK。
-        #   3) OK    —— provider 真正回了 200（body 含 "Hello" 或 "status code: 200"）
-        if echo "$body" | grep -q "call aborted"; then
+        #   1) ABORT    —— body 命中 "call aborted" 或 "circuit breaker open"
+        #                  （后者是 demo writeResult 在无 fallback 时的 503 兜底文案，
+        #                   反向用例 enable=false 走这条），说明 polaris-go 拦截了调用。
+        #   2) FALLBACK —— 命中规则配置的降级响应：HTTP=599 且 body 含 "degraded"
+        #                  （demo 在 abort.HasFallback() 时透传规则的 code/body/headers）。
+        #                  必须放在 FAIL(http!=200) 分支之前，否则 599 被误判为 FAIL。
+        #   3) FAIL     —— 上游返回非 200，或 consumer 透传了 provider 的 5xx 状态。
+        #                  注意：当前 demo 中 consumer 在 provider 5xx 时仍 WriteHeader(200)，
+        #                  把原 body（含 "status code: 500, Fatal, ..."）原样回写，因此必须
+        #                  同时检测 body 中的 5xx 提示，避免把失败错算成 OK。
+        #   4) OK       —— provider 真正回了 200（body 含 "Hello" 或 "status code: 200"）
+        if echo "$body" | grep -qE "call aborted|circuit breaker open"; then
             CASE_ABORT=$((CASE_ABORT + 1))
             verdict="ABORT"
             verdict_color="${YELLOW}"
+        elif [[ "$http_code" == "599" ]] && echo "$body" | grep -q "degraded"; then
+            CASE_FALLBACK=$((CASE_FALLBACK + 1))
+            verdict="FALLBACK"
+            verdict_color="${CYAN}"
         elif [[ "$http_code" != "200" ]] \
             || echo "$body" | grep -qE "status code: 5[0-9][0-9]" \
             || echo "$body" | grep -q "Fatal" \
@@ -1692,7 +1865,7 @@ run_burst() {
         sleep 0.05
     done
     echo "" >&2
-    log_info "[${label}] total=${CASE_TOTAL}, ok=${CASE_OK}, fail=${CASE_FAIL}, abort=${CASE_ABORT}"
+    log_info "[${label}] total=${CASE_TOTAL}, ok=${CASE_OK}, fail=${CASE_FAIL}, abort=${CASE_ABORT}, fallback=${CASE_FALLBACK}"
 }
 
 # ======================== 三个子用例 ========================
@@ -1728,7 +1901,7 @@ case_instance() {
         "  · source=*/*, destination=${NAMESPACE}/${SERVICE_NAME}" \
         "  · ErrorCondition: RET_CODE RANGE 500~599 (4xx 不计入熔断)" \
         "  · TriggerCondition: CONSECUTIVE_ERROR=5 / ERROR_RATE=50%@30s, minRequest=10" \
-        "  · RecoverCondition: sleepWindow=12s, consecutiveSuccess=1" \
+        "  · RecoverCondition: sleepWindow=6s, consecutiveSuccess=1" \
         "" \
         "验证步骤:" \
         "  1.1 provider-a=200 / provider-b=500" \
@@ -1797,7 +1970,7 @@ case_instance() {
     local r1_trigger_fail=$CASE_FAIL
 
     log_step "用例1.5 [轮1] 验证：再发 ${RECOVERY_REQUEST_COUNT} 次，期望全部 200"
-    sleep 2
+    sleep 1
     run_burst "$INSTANCE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "实例级验证-轮1"
     local r1_verify_ok=$CASE_OK
 
@@ -1816,7 +1989,7 @@ case_instance() {
     local r2_trigger_fail=$CASE_FAIL
 
     log_step "用例1.8 [轮2] 验证：再发 ${RECOVERY_REQUEST_COUNT} 次，期望全部 200"
-    sleep 2
+    sleep 1
     run_burst "$INSTANCE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "实例级验证-轮2"
     local r2_verify_ok=$CASE_OK
 
@@ -1847,7 +2020,7 @@ case_instance() {
     local i_trigger_fail=$CASE_FAIL
 
     log_step "用例1.12 [InvokeHandler] verify: 再发 ${RECOVERY_REQUEST_COUNT} 次，期望全部 200"
-    sleep 2
+    sleep 1
     run_burst "$INSTANCE_INVOKE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "实例级InvokeHandler验证"
     local i_verify_ok=$CASE_OK
 
@@ -1906,7 +2079,7 @@ case_service() {
         "  · source=*/${SERVICE_CALLER}, destination=${NAMESPACE}/${SERVICE_NAME}" \
         "  · ErrorCondition: RET_CODE RANGE 500~599 (4xx 不计入熔断)" \
         "  · TriggerCondition: CONSECUTIVE_ERROR=5 / ERROR_RATE=50%@30s, minRequest=10" \
-        "  · RecoverCondition: sleepWindow=12s, consecutiveSuccess=1" \
+        "  · RecoverCondition: sleepWindow=6s, consecutiveSuccess=1" \
         "" \
         "与实例级的差别:" \
         "  实例级摘单个故障实例，剩余实例继续承接流量；" \
@@ -2042,14 +2215,93 @@ case_service() {
 
     stop_consumer "$invoke_pid"
 
+    # ───── fallback 子阶段：在原 cb-service 规则上打开自定义降级，验证降级响应生效 ─────
+    # 复用 Decorator 阶段创建的同一条规则（id=$rule_id），通过 PUT 追加 fallbackConfig.enable=true。
+    # 打开后，熔断 OPEN 的响应从 ABORT(503) 变为 FALLBACK(HTTP 599 + body "degraded")——两者
+    # 都代表熔断已生效，只是有无 fallback 决定表现形态。规则 revision 变更会触发 SDK counter 重建，
+    # 因此 PUT 后需等待规则下发并重启 consumer，确保拿到带 fallback 的新规则。
+    local svc_fallback=0
+    local svc_fb_off_abort=0
+    if [[ -n "$rule_id" ]]; then
+        # ── 正向：enable=true → 熔断 OPEN 后透传 HTTP 599 ──
+        log_step "用例2.14 [fallback 正向] PUT 更新 cb-service-${SERVICE_CALLER} 打开自定义降级（enable=true, code=599）"
+        local fb_body
+        fb_body=$(build_rule_body_service_fallback_on)
+        if update_circuitbreaker_rule "service_fallback_on" "$rule_id" "$fb_body"; then
+            sleep "$WAIT_RULE_READY_SECONDS"
+
+            log_step "用例2.15 [fallback 正向] 重启 consumer（selfService=${SERVICE_CALLER}），加载带 fallback 的新规则"
+            if start_consumer "service_fallback_consumer" "$SERVICE_CONSUMER_DIR" \
+                "$SERVICE_CALLER" "$SERVICE_CONSUMER_PORT" \
+                "${LOG_DIR}/service_fallback_consumer.log"; then
+                local fb_pid="$_STARTED_PID"
+
+                log_step "用例2.16 [fallback 正向] trigger: a/b=500, 发 ${TRIGGER_REQUEST_COUNT} 次触发熔断"
+                provider_set_error "$PROVIDER_A_PORT" "true"
+                provider_set_error "$PROVIDER_B_PORT" "true"
+                run_burst "$SERVICE_CONSUMER_PORT" "$TRIGGER_REQUEST_COUNT" "服务级fallback正向触发"
+
+                log_step "用例2.17 [fallback 正向] verify: 再发 ${RECOVERY_REQUEST_COUNT} 次，期望出现 fallback（HTTP 599）"
+                sleep 1
+                run_burst "$SERVICE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "服务级fallback正向验证"
+                svc_fallback=$CASE_FALLBACK
+
+                provider_set_error "$PROVIDER_A_PORT" "false"
+                provider_set_error "$PROVIDER_B_PORT" "false"
+                stop_consumer "$fb_pid"
+            else
+                log_error "[用例2.15] fallback 正向 consumer 启动失败"
+            fi
+
+            # ── 反向：enable=false → enable 短路 → 熔断 OPEN 回退为 503/ABORT ──
+            # PUT 改 revision 触发 SDK counter 重建，状态从 Close 重新开始，无需显式 recover。
+            log_step "用例2.18 [fallback 反向] PUT 更新 cb-service-${SERVICE_CALLER} 关闭自定义降级（enable=false）"
+            local fb_off_body
+            fb_off_body=$(build_rule_body_service_fallback_off)
+            if update_circuitbreaker_rule "service_fallback_off" "$rule_id" "$fb_off_body"; then
+                sleep "$WAIT_RULE_READY_SECONDS"
+
+                log_step "用例2.19 [fallback 反向] 重启 consumer，加载 enable=false 的规则"
+                if start_consumer "service_fallback_off_consumer" "$SERVICE_CONSUMER_DIR" \
+                    "$SERVICE_CALLER" "$SERVICE_CONSUMER_PORT" \
+                    "${LOG_DIR}/service_fallback_off_consumer.log"; then
+                    local fb_off_pid="$_STARTED_PID"
+
+                    log_step "用例2.20 [fallback 反向] trigger: a/b=500, 发 ${TRIGGER_REQUEST_COUNT} 次触发熔断"
+                    provider_set_error "$PROVIDER_A_PORT" "true"
+                    provider_set_error "$PROVIDER_B_PORT" "true"
+                    run_burst "$SERVICE_CONSUMER_PORT" "$TRIGGER_REQUEST_COUNT" "服务级fallback反向触发"
+
+                    log_step "用例2.21 [fallback 反向] verify: 再发 ${RECOVERY_REQUEST_COUNT} 次，期望回退为 abort（503，不下发 599）"
+                    sleep 1
+                    run_burst "$SERVICE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "服务级fallback反向验证"
+                    svc_fb_off_abort=$CASE_ABORT
+
+                    provider_set_error "$PROVIDER_A_PORT" "false"
+                    provider_set_error "$PROVIDER_B_PORT" "false"
+                    stop_consumer "$fb_off_pid"
+                else
+                    log_error "[用例2.19] fallback 反向 consumer 启动失败"
+                fi
+            else
+                log_error "[用例2.18] PUT 关闭 fallback 失败"
+            fi
+        else
+            log_error "[用例2.14] PUT 打开 fallback 失败"
+        fi
+    else
+        log_warn "[用例2.14] 未取得 cb-service 规则 id，跳过 fallback 子阶段"
+    fi
+
     if [[ "$r1_trigger_fail" -ge 1 ]] && [[ "$r1_verify_abort" -ge 1 ]] && [[ "$r1_recover_ok" -ge 1 ]] \
         && [[ "$r2_trigger_fail" -ge 1 ]] && [[ "$r2_verify_abort" -ge 1 ]] && [[ "$r2_recover_ok" -ge 1 ]] \
-        && [[ "$i_trigger_fail" -ge 1 ]] && [[ "$i_verify_abort" -ge 1 ]] && [[ "$i_recover_ok" -ge 1 ]]; then
-        log_info "✅ 用例2 PASS: Decorator轮1[trigger=${r1_trigger_fail} abort=${r1_verify_abort} recover=${r1_recover_ok}] 轮2[trigger=${r2_trigger_fail} abort=${r2_verify_abort} recover=${r2_recover_ok}] InvokeHandler[trigger=${i_trigger_fail} abort=${i_verify_abort} recover=${i_recover_ok}]"
+        && [[ "$i_trigger_fail" -ge 1 ]] && [[ "$i_verify_abort" -ge 1 ]] && [[ "$i_recover_ok" -ge 1 ]] \
+        && [[ "$svc_fallback" -ge 1 ]] && [[ "$svc_fb_off_abort" -ge 1 ]]; then
+        log_info "✅ 用例2 PASS: Decorator轮1[trigger=${r1_trigger_fail} abort=${r1_verify_abort} recover=${r1_recover_ok}] 轮2[trigger=${r2_trigger_fail} abort=${r2_verify_abort} recover=${r2_recover_ok}] InvokeHandler[trigger=${i_trigger_fail} abort=${i_verify_abort} recover=${i_recover_ok}] fallback[正向degraded=${svc_fallback} 反向abort=${svc_fb_off_abort}]"
         echo "PASS"
         return 0
     fi
-    log_error "❌ 用例2 FAIL: Decorator轮1[trigger=${r1_trigger_fail} abort=${r1_verify_abort} recover=${r1_recover_ok}] 轮2[trigger=${r2_trigger_fail} abort=${r2_verify_abort} recover=${r2_recover_ok}] InvokeHandler[trigger=${i_trigger_fail} abort=${i_verify_abort} recover=${i_recover_ok}]"
+    log_error "❌ 用例2 FAIL: Decorator轮1[trigger=${r1_trigger_fail} abort=${r1_verify_abort} recover=${r1_recover_ok}] 轮2[trigger=${r2_trigger_fail} abort=${r2_verify_abort} recover=${r2_recover_ok}] InvokeHandler[trigger=${i_trigger_fail} abort=${i_verify_abort} recover=${i_recover_ok}] fallback[正向degraded=${svc_fallback} 反向abort=${svc_fb_off_abort}]"
     echo "FAIL"
     return 1
 }
@@ -2058,7 +2310,7 @@ case_service() {
 # 验证三组语义：
 #
 #   A. /echo 完整生命周期（两轮：触发 → 熔断 → 恢复 → 再次触发 → 再次熔断 → 再次恢复）
-#      规则阈值 CONSECUTIVE_ERROR=5，sleepWindow=12s
+#      规则阈值 CONSECUTIVE_ERROR=5，sleepWindow=6s
 #      ErrorConditions 同时挂 5 条 RET_CODE 匹配，覆盖
 #      RANGE / EXACT / REGEX / IN / NOT_IN 五种 MatchString 类型，
 #      作为"返回码支持范围,全匹配,正则,包含,不包含"的演示。
@@ -2095,7 +2347,7 @@ case_interface() {
         "      · ErrorCondition: 5 条 RET_CODE 同时挂，覆盖 RANGE/EXACT/REGEX/" \
         "          IN/NOT_IN — 全部只命中 5xx，4xx 不计入熔断" \
         "      · Trigger: CONSECUTIVE_ERROR=5 / ERROR_RATE=50%@30s, minReq=10" \
-        "      · Recover: sleepWindow=12s, consecutiveSuccess=1" \
+        "      · Recover: sleepWindow=6s, consecutiveSuccess=1" \
         "      · BlockConfig /order : 极高阈值不触发" \
         "      · 阈值故意调高: CONSECUTIVE_ERROR=100 / ERROR_RATE=99%@30s, minReq=200" \
         "      · 演示\"两个接口配置不同的规则会按各自规则生效\"" \
@@ -2286,12 +2538,92 @@ case_interface() {
 
     stop_consumer "$invoke_pid"
 
+    # ───── fallback 子阶段：在原 cb-interface 规则上打开自定义降级，验证降级响应生效 ─────
+    # 复用 Decorator 阶段创建的同一条 merged 规则（id=$rule_id），通过 PUT 在顶层追加
+    # fallbackConfig.enable=true（fallbackConfig 是 Rule 级字段，三个 block 共享）。对 /echo
+    # trigger 触发 echo-block 熔断 OPEN 后，响应从 ABORT(503) 变为 FALLBACK(HTTP 599 + "degraded")。
+    # 规则 revision 变更触发 SDK counter 重建，故 PUT 后等待下发并重启 consumer。
+    local iface_fallback=0
+    local iface_fb_off_abort=0
+    if [[ -n "$rule_id" ]]; then
+        # ── 正向：enable=true → /echo 熔断 OPEN 后透传 HTTP 599 ──
+        log_step "用例3.19 [fallback 正向] PUT 更新 cb-interface-${INTERFACE_CALLER} 打开自定义降级（enable=true, code=599）"
+        local fb_body
+        fb_body=$(build_rule_body_interface_fallback_on)
+        if update_circuitbreaker_rule "interface_fallback_on" "$rule_id" "$fb_body"; then
+            sleep "$WAIT_RULE_READY_SECONDS"
+
+            log_step "用例3.20 [fallback 正向] 重启 consumer（selfService=${INTERFACE_CALLER}），加载带 fallback 的新规则"
+            if start_consumer "interface_fallback_consumer" "$INTERFACE_CONSUMER_DIR" \
+                "$INTERFACE_CALLER" "$INTERFACE_CONSUMER_PORT" \
+                "${LOG_DIR}/interface_fallback_consumer.log"; then
+                local fb_pid="$_STARTED_PID"
+
+                log_step "用例3.21 [fallback 正向] trigger: a/b=500, 发 ${TRIGGER_REQUEST_COUNT} 次到 /echo 触发熔断"
+                provider_set_error "$PROVIDER_A_PORT" "true"
+                provider_set_error "$PROVIDER_B_PORT" "true"
+                run_burst "$INTERFACE_CONSUMER_PORT" "$TRIGGER_REQUEST_COUNT" "接口级fallback正向触发" "/echo"
+
+                log_step "用例3.22 [fallback 正向] verify: 再发 ${RECOVERY_REQUEST_COUNT} 次到 /echo，期望出现 fallback（HTTP 599）"
+                sleep 1
+                run_burst "$INTERFACE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "接口级fallback正向验证" "/echo"
+                iface_fallback=$CASE_FALLBACK
+
+                provider_set_error "$PROVIDER_A_PORT" "false"
+                provider_set_error "$PROVIDER_B_PORT" "false"
+                stop_consumer "$fb_pid"
+            else
+                log_error "[用例3.20] fallback 正向 consumer 启动失败"
+            fi
+
+            # ── 反向：enable=false → enable 短路 → /echo 熔断 OPEN 回退为 503/ABORT ──
+            # PUT 改 revision 触发 SDK counter 重建，状态从 Close 重新开始，无需显式 recover。
+            log_step "用例3.23 [fallback 反向] PUT 更新 cb-interface-${INTERFACE_CALLER} 关闭自定义降级（enable=false）"
+            local fb_off_body
+            fb_off_body=$(build_rule_body_interface_fallback_off)
+            if update_circuitbreaker_rule "interface_fallback_off" "$rule_id" "$fb_off_body"; then
+                sleep "$WAIT_RULE_READY_SECONDS"
+
+                log_step "用例3.24 [fallback 反向] 重启 consumer，加载 enable=false 的规则"
+                if start_consumer "interface_fallback_off_consumer" "$INTERFACE_CONSUMER_DIR" \
+                    "$INTERFACE_CALLER" "$INTERFACE_CONSUMER_PORT" \
+                    "${LOG_DIR}/interface_fallback_off_consumer.log"; then
+                    local fb_off_pid="$_STARTED_PID"
+
+                    log_step "用例3.25 [fallback 反向] trigger: a/b=500, 发 ${TRIGGER_REQUEST_COUNT} 次到 /echo 触发熔断"
+                    provider_set_error "$PROVIDER_A_PORT" "true"
+                    provider_set_error "$PROVIDER_B_PORT" "true"
+                    run_burst "$INTERFACE_CONSUMER_PORT" "$TRIGGER_REQUEST_COUNT" "接口级fallback反向触发" "/echo"
+
+                    log_step "用例3.26 [fallback 反向] verify: 再发 ${RECOVERY_REQUEST_COUNT} 次到 /echo，期望回退为 abort（503，不下发 599）"
+                    sleep 1
+                    run_burst "$INTERFACE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "接口级fallback反向验证" "/echo"
+                    iface_fb_off_abort=$CASE_ABORT
+
+                    provider_set_error "$PROVIDER_A_PORT" "false"
+                    provider_set_error "$PROVIDER_B_PORT" "false"
+                    stop_consumer "$fb_off_pid"
+                else
+                    log_error "[用例3.24] fallback 反向 consumer 启动失败"
+                fi
+            else
+                log_error "[用例3.23] PUT 关闭 fallback 失败"
+            fi
+        else
+            log_error "[用例3.19] PUT 打开 fallback 失败"
+        fi
+    else
+        log_warn "[用例3.19] 未取得 cb-interface 规则 id，跳过 fallback 子阶段"
+    fi
+
     # 通过条件：
     #   /echo 两轮 trigger / verify / recover 全部满足
     #   /order 整批失败且不应 abort
     #   /info  整批失败且不应 abort
     #   /slow  trigger 阶段有请求触发（OK 或 abort 都算），verify 阶段出现 abort，
     #         恢复阶段全部 200
+    #   fallback 正向：打开降级后 /echo 熔断出现 FALLBACK(HTTP 599)
+    #   fallback 反向：关闭降级（enable=false）后 /echo 熔断回退为 ABORT(503)
     if [[ "$r1_echo_trigger_fail" -ge 1 ]] \
         && [[ "$r1_echo_verify_abort" -ge 1 ]] \
         && [[ "$r1_echo_recover_ok" -eq "$RECOVERY_REQUEST_COUNT" ]] \
@@ -2305,12 +2637,14 @@ case_interface() {
         && [[ "$slow_recover_ok" -eq "$RECOVERY_REQUEST_COUNT" ]] \
         && [[ "$i_trigger_fail" -ge 1 ]] \
         && [[ "$i_verify_abort" -ge 1 ]] \
-        && [[ "$i_recover_ok" -ge 1 ]]; then
-        log_info "✅ 用例3 PASS: /echo Decorator轮1[trigger=${r1_echo_trigger_fail} abort=${r1_echo_verify_abort} recover=${r1_echo_recover_ok}] 轮2[trigger=${r2_echo_trigger_fail} abort=${r2_echo_verify_abort} recover=${r2_echo_recover_ok}], /order fail=${order_fail} abort=${order_abort}, /info fail=${info_fail} abort=${info_abort}, /slow verify_abort=${slow_verify_abort} recover_ok=${slow_recover_ok}, InvokeHandler[trigger=${i_trigger_fail} abort=${i_verify_abort} recover=${i_recover_ok}]"
+        && [[ "$i_recover_ok" -ge 1 ]] \
+        && [[ "$iface_fallback" -ge 1 ]] \
+        && [[ "$iface_fb_off_abort" -ge 1 ]]; then
+        log_info "✅ 用例3 PASS: /echo Decorator轮1[trigger=${r1_echo_trigger_fail} abort=${r1_echo_verify_abort} recover=${r1_echo_recover_ok}] 轮2[trigger=${r2_echo_trigger_fail} abort=${r2_echo_verify_abort} recover=${r2_echo_recover_ok}], /order fail=${order_fail} abort=${order_abort}, /info fail=${info_fail} abort=${info_abort}, /slow verify_abort=${slow_verify_abort} recover_ok=${slow_recover_ok}, InvokeHandler[trigger=${i_trigger_fail} abort=${i_verify_abort} recover=${i_recover_ok}], fallback[正向degraded=${iface_fallback} 反向abort=${iface_fb_off_abort}]"
         echo "PASS"
         return 0
     fi
-    log_error "❌ 用例3 FAIL: /echo Decorator轮1[trigger=${r1_echo_trigger_fail} abort=${r1_echo_verify_abort} recover=${r1_echo_recover_ok}] 轮2[trigger=${r2_echo_trigger_fail} abort=${r2_echo_verify_abort} recover=${r2_echo_recover_ok}], /order fail=${order_fail} abort=${order_abort}, /info fail=${info_fail} abort=${info_abort}, /slow verify_abort=${slow_verify_abort} recover_ok=${slow_recover_ok}, InvokeHandler[trigger=${i_trigger_fail} abort=${i_verify_abort} recover=${i_recover_ok}]"
+    log_error "❌ 用例3 FAIL: /echo Decorator轮1[trigger=${r1_echo_trigger_fail} abort=${r1_echo_verify_abort} recover=${r1_echo_recover_ok}] 轮2[trigger=${r2_echo_trigger_fail} abort=${r2_echo_verify_abort} recover=${r2_echo_recover_ok}], /order fail=${order_fail} abort=${order_abort}, /info fail=${info_fail} abort=${info_abort}, /slow verify_abort=${slow_verify_abort} recover_ok=${slow_recover_ok}, InvokeHandler[trigger=${i_trigger_fail} abort=${i_verify_abort} recover=${i_recover_ok}], fallback[正向degraded=${iface_fallback} 反向abort=${iface_fb_off_abort}]"
     echo "FAIL"
     return 1
 }
@@ -2354,7 +2688,7 @@ case_old_instance() {
         "  · source=*/*, destination=${NAMESPACE}/${SERVICE_NAME}" \
         "  · ErrorCondition: RET_CODE RANGE 500~599 (4xx 不计入熔断)" \
         "  · TriggerCondition: CONSECUTIVE_ERROR=5 / ERROR_RATE=50%@30s, minRequest=10" \
-        "  · RecoverCondition: sleepWindow=12s, consecutiveSuccess=1" \
+        "  · RecoverCondition: sleepWindow=6s, consecutiveSuccess=1" \
         "" \
         "验证目的:" \
         "  · 保证存量客户在新版 SDK 中沿用旧版散装写法依旧可以触发实例级熔断" \
@@ -2426,7 +2760,7 @@ case_old_instance() {
     local r1_trigger_fail=$CASE_FAIL
 
     log_step "用例4.5 [轮1] 验证：再发 ${RECOVERY_REQUEST_COUNT} 次，期望全部 200"
-    sleep 2
+    sleep 1
     run_burst "$OLD_INSTANCE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "旧版实例级验证-轮1"
     local r1_verify_ok=$CASE_OK
 
@@ -2445,7 +2779,7 @@ case_old_instance() {
     local r2_trigger_fail=$CASE_FAIL
 
     log_step "用例4.8 [轮2] 验证：再发 ${RECOVERY_REQUEST_COUNT} 次，期望全部 200"
-    sleep 2
+    sleep 1
     run_burst "$OLD_INSTANCE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "旧版实例级验证-轮2"
     local r2_verify_ok=$CASE_OK
 
@@ -2505,7 +2839,7 @@ case_http_status() {
         "  · source=*/*, destination=${NAMESPACE}/${SERVICE_NAME}" \
         "  · ErrorCondition: RET_CODE RANGE 500~599 (4xx 不计入熔断)" \
         "  · TriggerCondition: CONSECUTIVE_ERROR=3 (收紧阈值便于快速验证)" \
-        "  · RecoverCondition: sleepWindow=12s, consecutiveSuccess=1" \
+        "  · RecoverCondition: sleepWindow=6s, consecutiveSuccess=1" \
         "" \
         "验证步骤:" \
         "  5.1 provider-a=200 / provider-b=200" \
@@ -2579,7 +2913,7 @@ case_http_status() {
     local b_trigger_fail=$CASE_FAIL
 
     log_step "用例5.6 [B段] 验证 ${RECOVERY_REQUEST_COUNT} 次 /echo 全部走 a"
-    sleep 2
+    sleep 1
     run_burst "$HTTP_STATUS_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "5xx 验证"
     local b_verify_ok=$CASE_OK
     local b_verify_abort=$CASE_ABORT
@@ -2701,7 +3035,7 @@ case_http_status() {
 # 默认规则的形态（来自 default.go）：
 #   Level=INSTANCE, ErrorCondition: RetCode RANGE 500~599
 #   Trigger: CONSECUTIVE_ERROR=3 + ERROR_RATE 50%@30s, minimumRequest=3（脚本侧 yaml 配置）
-#   Recover: sleepWindow=12s, consecutiveSuccess=1
+#   Recover: sleepWindow=6s, consecutiveSuccess=1
 #
 # 通过条件：
 #   - trigger 阶段 fail≥3（provider-b 持续 5xx，被默认规则计数）
@@ -2720,7 +3054,7 @@ case_default_rule() {
         "  · Level=INSTANCE, name=default-polaris-instance-circuit-breaker" \
         "  · ErrorCondition: RET_CODE RANGE 500~599 (4xx 不计入熔断)" \
         "  · TriggerCondition: CONSECUTIVE_ERROR=3 / ERROR_RATE=50%@30s, minRequest=3" \
-        "  · RecoverCondition: sleepWindow=12s, consecutiveSuccess=1" \
+        "  · RecoverCondition: sleepWindow=6s, consecutiveSuccess=1" \
         "  · 阈值通过 polaris.yaml 收紧（默认 SDK 是 10/10/30s/3）便于快速验证" \
         "" \
         "关键差别（与用例 1 对比）:" \
@@ -2776,7 +3110,7 @@ case_default_rule() {
     local trigger_fail=$CASE_FAIL
 
     log_step "用例6.5 验证：再发 ${RECOVERY_REQUEST_COUNT} 次，期望全部 200（流量走 a）"
-    sleep 2
+    sleep 1
     run_burst "$DEFAULT_RULE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "默认规则验证"
     local verify_ok=$CASE_OK
 
@@ -2827,7 +3161,7 @@ case_modify_rule() {
         "  · source=*/${MODIFY_RULE_CALLER}, destination=${NAMESPACE}/${SERVICE_NAME}" \
         "  · ErrorCondition: RET_CODE RANGE 500~599 (4xx 不计入熔断)" \
         "  · 轮1 CONSECUTIVE_ERROR=3，轮2 更新为 7" \
-        "  · RecoverCondition: sleepWindow=12s, consecutiveSuccess=1" \
+        "  · RecoverCondition: sleepWindow=6s, consecutiveSuccess=1" \
         "" \
         "验证步骤:" \
         "  7.1 provider-a=200 / provider-b=500" \
@@ -2890,7 +3224,7 @@ case_modify_rule() {
     local r1_trigger_fail=$CASE_FAIL
 
     log_step "用例7.5 [轮1] 验证：再发 ${RECOVERY_REQUEST_COUNT} 次，期望全部 200"
-    sleep 2
+    sleep 1
     run_burst "$MODIFY_RULE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "修改规则验证-轮1"
     local r1_verify_ok=$CASE_OK
 
@@ -2927,7 +3261,7 @@ case_modify_rule() {
     local r2_trigger_fail=$CASE_FAIL
 
     log_step "用例7.10 [轮2] 验证：再发 ${RECOVERY_REQUEST_COUNT} 次，期望全部 200"
-    sleep 2
+    sleep 1
     run_burst "$MODIFY_RULE_CONSUMER_PORT" "$RECOVERY_REQUEST_COUNT" "修改规则验证-轮2"
     local r2_verify_ok=$CASE_OK
 
@@ -3048,7 +3382,7 @@ case_protocol_method() {
         local t_fail=$CASE_FAIL
         local t_abort=$CASE_ABORT
 
-        sleep 2
+        sleep 1
         run_burst "$PM_CONSUMER_PORT" "$PM_VERIFY_COUNT" "8.proto-$proto-verify" "/api/protocol/$proto"
         local v_ok=$CASE_OK
         local v_abort=$CASE_ABORT
@@ -3087,7 +3421,7 @@ case_protocol_method() {
         local t_fail=$CASE_FAIL
         local t_abort=$CASE_ABORT
 
-        sleep 2
+        sleep 1
         run_burst "$PM_CONSUMER_PORT" "$PM_VERIFY_COUNT" "8.meth-$meth-verify" "/api/method/$meth"
         local v_ok=$CASE_OK
         local v_abort=$CASE_ABORT
@@ -3221,7 +3555,7 @@ case_pathtype() {
         local t_fail=$CASE_FAIL
         local t_abort=$CASE_ABORT
 
-        sleep 2
+        sleep 1
         run_burst "$PATHTYPE_CONSUMER_PORT" "$PATHTYPE_VERIFY_COUNT" "9.$ptype_label-verify" "$req_path"
         local v_ok=$CASE_OK
         local v_abort=$CASE_ABORT
@@ -3326,7 +3660,7 @@ _run_all_dead_phase() {
     log_step "[${phase_label}.4] verify: a/b 翻回 200，验证全死全活生效"
     provider_set_error "$PROVIDER_A_PORT" "false"
     provider_set_error "$PROVIDER_B_PORT" "false"
-    sleep 2
+    sleep 1
     run_burst "$port" "$RECOVERY_REQUEST_COUNT" "${phase_label}验证"
     local a_verify_ok=$CASE_OK
 
@@ -3339,7 +3673,7 @@ _run_all_dead_phase() {
     # ── 全死全活关闭 ──
     log_step "[${phase_label}.6] 重启 consumer（enableRecoverAll=false）"
     stop_consumer "$consumer_pid"
-    sleep 2
+    sleep 1
     if ! start_consumer "${phase_label}_consumer_b" "$consumer_dir" \
         "$caller" "$port" "${log_file%.log}_b.log" "false" "false"; then
         return 1
@@ -3353,18 +3687,23 @@ _run_all_dead_phase() {
     run_burst "$port" "60" "${phase_label}触发B"
     local b_trigger_fail=$CASE_FAIL
 
-    # verify: 全死全活关闭 → GetOneInstance 失败
-    log_step "[${phase_label}.8] verify: a/b 翻回 200，验证全死全活关闭"
-    provider_set_error "$PROVIDER_A_PORT" "false"
-    provider_set_error "$PROVIDER_B_PORT" "false"
-    sleep 2
+    # verify: 全死全活关闭 → 实例 OPEN 时 healthyInstances 为空 → GetOneInstance 失败
+    # 关键：此处必须保持 a/b=500（不翻回 200）。验证意图是"实例仍 OPEN + 全死全活关闭
+    # → 无可选实例 → 调用失败"，仅在实例 OPEN 时成立。若先翻回 200，且 B.7 的 60 次
+    # trigger burst 耗时超过 sleepWindow（压缩后 6s）导致实例已进半开，半开探测会命中
+    # 200 而恢复，verify 变成全 200，预期的 b_verify_fail 落空。保持 500 则即使进半开
+    # 探测也会失败重新 OPEN，验证结果稳定且与 sleepWindow/burst 耗时无关。
+    # provider 翻回 200 属于 B.9 recover 阶段的职责。
+    log_step "[${phase_label}.8] verify: 保持 a/b=500，验证全死全活关闭时实例不可选"
     run_burst "$port" "$RECOVERY_REQUEST_COUNT" "${phase_label}验证B"
     local b_verify_fail=$CASE_FAIL
 
-    # recover: 重启 consumer 恢复 enableRecoverAll=true
-    log_step "[${phase_label}.9] recover: 重启 consumer（恢复 enableRecoverAll=true）"
+    # recover: 把 provider 翻回 200（B.8 不再负责复位），重启 consumer 恢复 enableRecoverAll=true
+    log_step "[${phase_label}.9] recover: a/b 翻回 200，重启 consumer（恢复 enableRecoverAll=true）"
+    provider_set_error "$PROVIDER_A_PORT" "false"
+    provider_set_error "$PROVIDER_B_PORT" "false"
     stop_consumer "$consumer_pid"
-    sleep 2
+    sleep 1
     if ! start_consumer "${phase_label}_consumer_c" "$consumer_dir" \
         "$caller" "$port" "${log_file%.log}_c.log" "false" "true"; then
         return 1

--- a/plugin/circuitbreaker/composite/counter.go
+++ b/plugin/circuitbreaker/composite/counter.go
@@ -55,7 +55,8 @@ type ResourceCounters struct {
 	resource model.Resource
 	// statusRef 状态机原子引用，承载 *model.CircuitBreakerStatusWrapper
 	statusRef atomic.Value
-	// fallbackInfo 降级响应信息（保留字段，本期不下发 body/headers）
+	// fallbackInfo 降级响应信息，构造时一次性从规则的 FallbackConfig 解析缓存，
+	// 仅在 toOpen() 注入到 OPEN 状态，含 code/body/headers
 	fallbackInfo *model.FallbackInfo
 	// regexFunction 正则编译函数，复用 CompositeCircuitBreaker 的 regex 缓存
 	regexFunction func(string) *regexp.Regexp
@@ -327,23 +328,24 @@ func buildFallbackInfo(rule *fault_tolerance.CircuitBreakerRule) *model.Fallback
 	if rule.GetLevel() != fault_tolerance.Level_METHOD && rule.GetLevel() != fault_tolerance.Level_SERVICE {
 		return nil
 	}
-	fallbackInfo := rule.GetFallbackConfig()
-	if fallbackInfo == nil {
+	// GetFallbackConfig() 在 proto 中即使规则未配置也会返回非 nil 零值 message，
+	// 因此必须显式判断 GetEnable()，否则 enable=false 的规则会被误当作启用的降级
+	// 配置，导致熔断时返回本不该返回的 code/body。
+	fallbackConfig := rule.GetFallbackConfig()
+	if fallbackConfig == nil || !fallbackConfig.GetEnable() {
 		return nil
 	}
-	if fallbackInfo.GetResponse() == nil {
+	resp := fallbackConfig.GetResponse()
+	if resp == nil {
 		return nil
 	}
 	ret := &model.FallbackInfo{
-		Code:    int(fallbackInfo.GetResponse().GetCode()),
-		Body:    fallbackInfo.GetResponse().GetBody(),
+		Code:    int(resp.GetCode()),
+		Body:    resp.GetBody(),
 		Headers: map[string]string{},
 	}
-
-	headers := fallbackInfo.GetResponse().GetHeaders()
-	for i := range headers {
-		header := headers[i]
-		ret.Headers[header.Key] = header.Value
+	for _, header := range resp.GetHeaders() {
+		ret.Headers[header.GetKey()] = header.GetValue()
 	}
 	return ret
 }

--- a/plugin/circuitbreaker/composite/fallback_test.go
+++ b/plugin/circuitbreaker/composite/fallback_test.go
@@ -1,0 +1,144 @@
+/**
+ * Tencent is pleased to support the open source community by making polaris-go available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package composite
+
+import (
+	"testing"
+
+	"github.com/polarismesh/specification/source/go/api/v1/fault_tolerance"
+	"github.com/stretchr/testify/assert"
+)
+
+// buildFallbackResponse 构造一条降级响应，简化测试代码
+func buildFallbackResponse(code int32, body string, headers map[string]string) *fault_tolerance.FallbackResponse {
+	resp := &fault_tolerance.FallbackResponse{
+		Code: code,
+		Body: body,
+	}
+	for k, v := range headers {
+		resp.Headers = append(resp.Headers, &fault_tolerance.FallbackResponse_MessageHeader{
+			Key:   k,
+			Value: v,
+		})
+	}
+	return resp
+}
+
+// TestBuildFallbackInfo_NilRule 测试场景：规则为 nil
+// 预期结果：返回 nil
+func TestBuildFallbackInfo_NilRule(t *testing.T) {
+	assert.Nil(t, buildFallbackInfo(nil))
+}
+
+// TestBuildFallbackInfo_InstanceLevelReturnsNil 测试场景：INSTANCE 级规则不支持降级
+// 前置条件：Level=INSTANCE，且配置了 enable=true 的完整 fallback
+// 预期结果：返回 nil（与 java composite 一致，仅 SERVICE/METHOD 支持）
+func TestBuildFallbackInfo_InstanceLevelReturnsNil(t *testing.T) {
+	rule := &fault_tolerance.CircuitBreakerRule{
+		Level: fault_tolerance.Level_INSTANCE,
+		FallbackConfig: &fault_tolerance.FallbackConfig{
+			Enable:   true,
+			Response: buildFallbackResponse(503, "degraded", nil),
+		},
+	}
+	assert.Nil(t, buildFallbackInfo(rule))
+}
+
+// TestBuildFallbackInfo_DisabledReturnsNil 测试场景：enable=false 不启用降级（D1 核心修正）
+// 前置条件：Level=SERVICE，FallbackConfig.Enable=false 但 response 非空
+// 预期结果：返回 nil，避免 enable=false 的规则被误当作启用的降级配置
+func TestBuildFallbackInfo_DisabledReturnsNil(t *testing.T) {
+	rule := &fault_tolerance.CircuitBreakerRule{
+		Level: fault_tolerance.Level_SERVICE,
+		FallbackConfig: &fault_tolerance.FallbackConfig{
+			Enable:   false,
+			Response: buildFallbackResponse(599, "should-not-appear", map[string]string{"X-Fallback": "true"}),
+		},
+	}
+	assert.Nil(t, buildFallbackInfo(rule))
+}
+
+// TestBuildFallbackInfo_NilConfigReturnsNil 测试场景：FallbackConfig 为 nil
+// 前置条件：Level=SERVICE，FallbackConfig 未设置
+// 预期结果：返回 nil
+func TestBuildFallbackInfo_NilConfigReturnsNil(t *testing.T) {
+	rule := &fault_tolerance.CircuitBreakerRule{
+		Level: fault_tolerance.Level_SERVICE,
+	}
+	assert.Nil(t, buildFallbackInfo(rule))
+}
+
+// TestBuildFallbackInfo_EnabledNilResponseReturnsNil 测试场景：enable=true 但 response 为空
+// 前置条件：Level=METHOD，Enable=true，Response=nil
+// 预期结果：返回 nil
+func TestBuildFallbackInfo_EnabledNilResponseReturnsNil(t *testing.T) {
+	rule := &fault_tolerance.CircuitBreakerRule{
+		Level: fault_tolerance.Level_METHOD,
+		FallbackConfig: &fault_tolerance.FallbackConfig{
+			Enable:   true,
+			Response: nil,
+		},
+	}
+	assert.Nil(t, buildFallbackInfo(rule))
+}
+
+// TestBuildFallbackInfo_ServiceLevelFullFields 测试场景：SERVICE 级完整降级配置逐字段映射
+// 前置条件：Level=SERVICE，Enable=true，response 含 code/body/headers
+// 预期结果：FallbackInfo 各字段与规则配置逐一相等
+func TestBuildFallbackInfo_ServiceLevelFullFields(t *testing.T) {
+	rule := &fault_tolerance.CircuitBreakerRule{
+		Level: fault_tolerance.Level_SERVICE,
+		FallbackConfig: &fault_tolerance.FallbackConfig{
+			Enable: true,
+			Response: buildFallbackResponse(599, "service degraded", map[string]string{
+				"X-Fallback":   "true",
+				"Content-Type": "text/plain",
+			}),
+		},
+	}
+
+	got := buildFallbackInfo(rule)
+
+	assert.NotNil(t, got)
+	assert.Equal(t, 599, got.Code)
+	assert.Equal(t, "service degraded", got.Body)
+	assert.Equal(t, "true", got.Headers["X-Fallback"])
+	assert.Equal(t, "text/plain", got.Headers["Content-Type"])
+	assert.Len(t, got.Headers, 2)
+}
+
+// TestBuildFallbackInfo_MethodLevelEmptyHeaders 测试场景：METHOD 级 headers 为空
+// 前置条件：Level=METHOD，Enable=true，response 只有 code/body
+// 预期结果：FallbackInfo.Headers 为非 nil 空 map，code/body 正确
+func TestBuildFallbackInfo_MethodLevelEmptyHeaders(t *testing.T) {
+	rule := &fault_tolerance.CircuitBreakerRule{
+		Level: fault_tolerance.Level_METHOD,
+		FallbackConfig: &fault_tolerance.FallbackConfig{
+			Enable:   true,
+			Response: buildFallbackResponse(429, "method degraded", nil),
+		},
+	}
+
+	got := buildFallbackInfo(rule)
+
+	assert.NotNil(t, got)
+	assert.Equal(t, 429, got.Code)
+	assert.Equal(t, "method degraded", got.Body)
+	assert.NotNil(t, got.Headers)
+	assert.Len(t, got.Headers, 0)
+}


### PR DESCRIPTION
---
 # Summary

  合入 feat/circuitbreaker-fallback → main，实现对熔断器自定义降级响应（FallbackConfig）的完整支持与端到端验证，修复此前 enable 判断缺失导致的逻辑缺陷及两个 demo 隐式 bug。

  # Changes

  1. SDK 修复 — plugin/circuitbreaker/composite/counter.go

  buildFallbackInfo 新增 GetEnable() 显式判定

  // 修复前：只判 nil，proto 零值 message 非 nil → enable=false 的规则被误当作启用
  fallbackInfo := rule.GetFallbackConfig()
  if fallbackInfo == nil { return nil }

  // 修复后：显式判断 GetEnable()，false 时正确短路
  fallbackConfig := rule.GetFallbackConfig()
  if fallbackConfig == nil || !fallbackConfig.GetEnable() { return nil }

  - 原因：GetFallbackConfig() 在 proto 中即使规则未配置也会返回非 nil 零值 message，单靠 nil 判断拦不住 enable=false 的规则。这会导致熔断时不该返回的 code/body 被误注入。
  - 同步重构：变量 fallbackInfo → fallbackConfig；headers 遍历从索引 i 改为 range；从 rule.GetFallbackConfig() 的返回值直接取 resp 避免重复调用。

  2. Demo 修复（两处）

  newCircuitBreakerCaller/consumer/main.go — writeResult

  修复判定顺序：先判 abort.HasFallback() 再判 err。修复前熔断拦截时 ErrorCallAborted 先命中 err 分支返回 500，导致 fallback/503 分支永远不可达。

  invokeHandlerCaller/consumer/main.go

  Header().Add() 移到 WriteHeader() 之前。net/http 在 WriteHeader() 之后禁止修改 header（静默丢弃），此前 fallback headers 实际从未下发。

  3. 新增单元测试 — plugin/circuitbreaker/composite/fallback_test.go

  buildFallbackInfo 7 个场景完整覆盖：
  - nil 规则 / INSTANCE 级别 / enable=false / nil response / 完整字段 / 空 headers / METHOD 级别

  4. 验证脚本 — verify_circuitbreaker.sh

  - 提效：全量规则 sleepWindow 12s → 6s，WAIT_HALF_OPEN 15s → 8s
  - 用例 2（SERVICE）/ 用例 3（METHOD）：各追加 fallback 正向（PUT enable=true → 验证 599 + "degraded by circuitbreaker"）+ 反向（PUT enable=false → 验证 503 短路）共 4 个子阶段，复用已有规则零新增规则
  - 用例 10（all_dead_fallback）：B 段 verify 改为保持 a/b=500 不翻回，消除 sleepWindow 压缩导致的半开竞态
  - 日志改进：_run_all_dead_phase 辅助函数全部 log_step 加"用例10"前缀

  5. 文档同步 — README.md / test.md

  - custom_fallback 验证点全并入用例 2/3
  - 更新规则清单、sleepWindow 等默认参数
  - 用例 2/3 补充 fallback 子阶段步骤与通过条件

  # Notes

  - 熔断 fallback 仅 SERVICE/METHOD 级别生效，INSTANCE 级别不支持（与协议定义一致，非 bug）
  - fallbackConfig 是 Rule 级字段，METHOD 级多 BlockConfig 共享同一份降级配置
  - 变更 不涉及 API/协议/接口层面的 breaking change，纯 bugfix + 测试增强